### PR TITLE
hotfix/CP-5896-android-capacitor-topics-dialog-not-visible-v1

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -2750,7 +2750,7 @@ public class CleverPush {
     } catch (Exception ignored) {
     }
     boolean defaultUncheckedAndEmptyTopics =
-        selectedTopics.size() == 0 && !this.hasSubscriptionTopics() && !defaultUnchecked;
+        selectedTopics.size() == 0 && !defaultUnchecked;
     return defaultUncheckedAndEmptyTopics || selectedTopics.contains(id);
   }
 


### PR DESCRIPTION
After installation on the app launch topics are not selected in the topic dialog.