### PR TITLE
hotfix/CP-6212-android-flutter-text-not-centered

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -14,6 +14,7 @@ import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.util.Base64;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -58,6 +59,7 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
   private static final String TAG = "CleverPush/AppBanner";
   private static final String CONTENT_TYPE_HTML = "html";
   private static final Map<Alignment, Integer> alignmentMap = new HashMap<>();
+  private static final Map<Alignment, Integer> gravityMap = new HashMap<>();
   private final Activity activity;
   private final Banner data;
   private final List<BannerScreens> screens = new LinkedList<>();
@@ -68,6 +70,12 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     alignmentMap.put(Alignment.Left, View.TEXT_ALIGNMENT_TEXT_START);
     alignmentMap.put(Alignment.Center, View.TEXT_ALIGNMENT_CENTER);
     alignmentMap.put(Alignment.Right, View.TEXT_ALIGNMENT_TEXT_END);
+  }
+
+  static {
+    gravityMap.put(Alignment.Left, Gravity.START);
+    gravityMap.put(Alignment.Center, Gravity.CENTER);
+    gravityMap.put(Alignment.Right, Gravity.END);
   }
 
   AppBannerCarouselAdapter(Activity activity, Banner banner, AppBannerPopup appBannerPopup,
@@ -177,6 +185,9 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     Integer alignment = alignmentMap.get(block.getAlignment());
     button.setTextAlignment(alignment == null ? View.TEXT_ALIGNMENT_CENTER : alignment);
 
+    Integer gravity = gravityMap.get(block.getAlignment());
+    button.setGravity(gravity == null ? Gravity.CENTER : gravity);
+
     LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
         LinearLayout.LayoutParams.MATCH_PARENT,
         LinearLayout.LayoutParams.MATCH_PARENT
@@ -251,6 +262,9 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
 
     Integer alignment = alignmentMap.get(block.getAlignment());
     textView.setTextAlignment(alignment == null ? View.TEXT_ALIGNMENT_CENTER : alignment);
+
+    Integer gravity = gravityMap.get(block.getAlignment());
+    textView.setGravity(gravity == null ? Gravity.CENTER : gravity);
 
     body.addView(textView);
   }

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
@@ -40,7 +40,6 @@ import com.cleverpush.CleverPushPreferences;
 import com.cleverpush.R;
 import com.cleverpush.banner.models.Banner;
 import com.cleverpush.banner.models.BannerScreens;
-import com.cleverpush.banner.models.blocks.Alignment;
 import com.cleverpush.banner.models.blocks.BannerBackground;
 import com.cleverpush.listener.AppBannerOpenedListener;
 import com.cleverpush.util.ColorUtils;
@@ -50,8 +49,6 @@ import com.google.android.material.tabs.TabLayoutMediator;
 
 import java.io.InputStream;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -61,13 +58,6 @@ public class AppBannerPopup {
   private static final String POSITION_TYPE_BOTTOM = "bottom";
   private static final String POSITION_TYPE_FULL = "full";
   private static final String TAG = "CleverPush/AppBanner";
-  private static final Map<Alignment, Integer> alignmentMap = new HashMap<>();
-
-  static {
-    alignmentMap.put(Alignment.Left, View.TEXT_ALIGNMENT_TEXT_START);
-    alignmentMap.put(Alignment.Center, View.TEXT_ALIGNMENT_CENTER);
-    alignmentMap.put(Alignment.Right, View.TEXT_ALIGNMENT_TEXT_END);
-  }
 
   private final int TAB_LAYOUT_DEFAULT_HEIGHT = 48;
   private final int MAIN_LAYOUT_PADDING = 15;

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailActivity.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailActivity.java
@@ -39,7 +39,6 @@ import com.cleverpush.Notification;
 import com.cleverpush.R;
 import com.cleverpush.banner.models.Banner;
 import com.cleverpush.banner.models.BannerScreens;
-import com.cleverpush.banner.models.blocks.Alignment;
 import com.cleverpush.banner.models.blocks.BannerBackground;
 import com.cleverpush.listener.ActivityInitializedListener;
 import com.cleverpush.listener.AppBannerOpenedListener;
@@ -57,27 +56,14 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
 public class InboxDetailActivity extends AppCompatActivity {
 
-  private static final String POSITION_TYPE_TOP = "top";
-  private static final String POSITION_TYPE_BOTTOM = "bottom";
-  private static final String POSITION_TYPE_FULL = "full";
-  private static final Map<Alignment, Integer> alignmentMap = new HashMap<>();
   private static final String TAG = "CleverPush/InboxDetail";
-
-  static {
-    alignmentMap.put(Alignment.Left, View.TEXT_ALIGNMENT_TEXT_START);
-    alignmentMap.put(Alignment.Center, View.TEXT_ALIGNMENT_CENTER);
-    alignmentMap.put(Alignment.Right, View.TEXT_ALIGNMENT_TEXT_END);
-  }
-
   private final int TAB_LAYOUT_DEFAULT_HEIGHT = 48;
   private final int MAIN_LAYOUT_PADDING = 15;
   private final HandlerThread handlerThread = new HandlerThread("InboxViewModule");

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
@@ -14,6 +14,7 @@ import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.util.Base64;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -60,11 +61,18 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
   private static final String TAG = "CleverPush/InboxDetailBanner";
   private static final String CONTENT_TYPE_HTML = "html";
   private static final Map<Alignment, Integer> alignmentMap = new HashMap<>();
+  private static final Map<Alignment, Integer> gravityMap = new HashMap<>();
 
   static {
     alignmentMap.put(Alignment.Left, View.TEXT_ALIGNMENT_TEXT_START);
     alignmentMap.put(Alignment.Center, View.TEXT_ALIGNMENT_CENTER);
     alignmentMap.put(Alignment.Right, View.TEXT_ALIGNMENT_TEXT_END);
+  }
+
+  static {
+    gravityMap.put(Alignment.Left, Gravity.START);
+    gravityMap.put(Alignment.Center, Gravity.CENTER);
+    gravityMap.put(Alignment.Right, Gravity.END);
   }
 
   private final Activity activity;
@@ -164,6 +172,9 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
     Integer alignment = alignmentMap.get(block.getAlignment());
     button.setTextAlignment(alignment == null ? View.TEXT_ALIGNMENT_CENTER : alignment);
 
+    Integer gravity = gravityMap.get(block.getAlignment());
+    button.setGravity(gravity == null ? Gravity.CENTER : gravity);
+
     LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
     params.setMargins(0, 20, 0, 20);
     button.setLayoutParams(params);
@@ -230,6 +241,9 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
 
     Integer alignment = alignmentMap.get(block.getAlignment());
     textView.setTextAlignment(alignment == null ? View.TEXT_ALIGNMENT_CENTER : alignment);
+
+    Integer gravity = gravityMap.get(block.getAlignment());
+    textView.setGravity(gravity == null ? Gravity.CENTER : gravity);
 
     body.addView(textView);
   }


### PR DESCRIPTION
set gravity for text alignment and removed unused alignmentMap