### PR TITLE
hotfix/CP-6412-android-trackevent-crash-error

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -2413,9 +2413,12 @@ public class CleverPush {
         }
         getAppBannerModule().triggerEvent(triggeredEvent);
       } catch (Exception ex) {
-        String message = ex.getMessage();
-        if (message == null) {
-          message = ex.toString();
+        String message = "Track event failed because of error";
+        if (ex != null) {
+          message = ex.getMessage();
+          if (message == null) {
+            message = ex.toString();
+          }
         }
         Logger.e(LOG_TAG, message);
       }


### PR DESCRIPTION
pass a null value to Logger because of that it gets crash.