### PR TITLE
hotfix/CP-6562-android-array-index-out-of-bounds-exception-set-subscription-attribute

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -1494,7 +1494,7 @@ public class CleverPush {
     return subscriptionId;
   }
 
-  public void getSubscriptionId(SubscribedListener listener) {
+  public synchronized void getSubscriptionId(SubscribedListener listener) {
     if (listener != null) {
       if (subscriptionId == null) {
         getSubscriptionIdListeners.add(listener);


### PR DESCRIPTION
Added synchronized in getSubscriptionId to prevent the race condition