### PR TITLE
feature/CP-6885-android-app-banner-frequency-setting-every-time-on-trigger-v1

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -824,6 +824,10 @@ public class AppBannerModule {
         getHandler().postDelayed(() -> showBanner(bannerPopup), delay + (1000L * banner.getDelaySeconds()));
       }
     }
+
+    if (currentEventId != null) {
+      currentEventId = null;
+    }
   }
 
   private boolean checkIsEveryTrigger(Banner banner, boolean isEveryTrigger) {


### PR DESCRIPTION
set currentEventId to null after showing the banner. so that we don't accidentally show the banner twice even though the event was only triggered once