### PR TITLE
hotfix/CP-7423-android-wrong-screen-id-sent-for-app-banner-buttons

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -233,6 +233,7 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     if (block.getAction() != null) {
       BannerAction action = block.getAction();
       action.setBlockId(block.getId());
+      action.setMultipleScreenId(data.getScreens().get(position).getId());
       button.setOnClickListener(view -> this.onClickListener(action));
     }
 
@@ -399,6 +400,7 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     if (block.getAction() != null) {
       BannerAction action = block.getAction();
       action.setBlockId(block.getId());
+      action.setMultipleScreenId(data.getScreens().get(blockPosition).getId());
       img.setOnClickListener(view -> this.onClickListener(action));
     }
   }

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -1118,7 +1118,7 @@ public class AppBannerModule {
       bannerPopup.setOpenedListener(action -> {
         String blockId, screenId;
         blockId = action.getBlockId();
-        screenId = action.getScreen();
+        screenId = action.getMultipleScreenId();
 
         boolean isElementAlreadyClicked = isBannerElementClicked(blockId);
         if (!isElementAlreadyClicked) {

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/BannerAction.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/BannerAction.java
@@ -23,6 +23,7 @@ public class BannerAction {
   private String screen;
   private Map<String, Object> customData;
   private String blockId;
+  private String multipleScreenId;
 
   private BannerAction() {
   }
@@ -85,6 +86,14 @@ public class BannerAction {
 
   public void setBlockId(String blockId) {
     this.blockId = blockId;
+  }
+
+  public String getMultipleScreenId() {
+    return multipleScreenId;
+  }
+
+  public void setMultipleScreenId(String multipleScreenId) {
+    this.multipleScreenId = multipleScreenId;
   }
 
   public static BannerAction create(JSONObject json) throws JSONException {


### PR DESCRIPTION
In the banner clicked API always send the current screen id when multiple screen is enabled.