### PR TITLE
hotfix/CP-7519-android-cmp-consent-subscribed-handler-issues-v1

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
+++ b/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
@@ -98,11 +98,15 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
 
     counter++;
 
-    // Register SharedPreferences.OnSharedPreferenceChangeListener
-    new Thread(() -> {
-      SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(currentActivity);
-      prefs.registerOnSharedPreferenceChangeListener(this);
-    }).start();
+    try {
+      // Register SharedPreferences.OnSharedPreferenceChangeListener
+      new Thread(() -> {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+        prefs.registerOnSharedPreferenceChangeListener(this);
+      }).start();
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "Error while registering OnSharedPreferenceChangeListener. " + e.getMessage(), e);
+    }
   }
 
   @Override
@@ -128,11 +132,15 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
 
     CleverPush.getInstance(CleverPush.context).resetInitSessionCalled();
 
-    // Unregister SharedPreferences.OnSharedPreferenceChangeListener
-    new Thread(() -> {
-      SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
-      prefs.unregisterOnSharedPreferenceChangeListener(this);
-    }).start();
+    try {
+      // Unregister SharedPreferences.OnSharedPreferenceChangeListener
+      new Thread(() -> {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+        prefs.unregisterOnSharedPreferenceChangeListener(this);
+      }).start();
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "Error while unregistering OnSharedPreferenceChangeListener. " + e.getMessage(), e);
+    }
   }
 
   @Override


### PR DESCRIPTION
Resolved CMP consent / subscribedHandler issues.
1. When consent is false then the event should not be stored in the queue for TCF
2. if tcf mode is set and setTrackingConsent is false then removeSubscriptionTagsAndAttributes should work.