### PR TITLE
hotfix/CP-7575-android-track-session-start-maybe-not-working-correctly-v1

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -1439,12 +1439,12 @@ public class CleverPush {
             self.subscriptionInProgress = false;
             Logger.d(LOG_TAG, "subscribed with ID: " + newSubscriptionId);
 
+            self.fireSubscribedListener(newSubscriptionId);
+            self.setSubscriptionId(newSubscriptionId);
+
             if (!isSessionStartCalled) {
               self.trackSessionStart();
             }
-
-            self.fireSubscribedListener(newSubscriptionId);
-            self.setSubscriptionId(newSubscriptionId);
 
             if (subscribedCallbackListener != null) {
               subscribedCallbackListener.onSuccess(newSubscriptionId);


### PR DESCRIPTION
Call trackSessionStart after setSubscriptionId