### PR TITLE
hotfix/CP-7709-android-java-util-concurrent-modification-exception-in-com-cleverpush-clever-push-set-tracking-consent-v1

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -1575,9 +1575,8 @@ public class CleverPush {
     }
 
     if (hasTrackingConsent) {
-      Iterator<TrackingConsentListener> iterator = trackingConsentListeners.iterator();
-      while (iterator.hasNext()) {
-        TrackingConsentListener listener = iterator.next();
+      Collection<TrackingConsentListener> copyTrackingConsentListeners = new ArrayList<>(trackingConsentListeners);
+      for (TrackingConsentListener listener : copyTrackingConsentListeners) {
         listener.ready();
       }
     }


### PR DESCRIPTION
It directly iterates over the original trackingConsentListeners collection using an Iterator. So used copyTrackingConsentListeners it operates on a copy of the collection.