### PR TITLE
hotfix/CP-8022-android-app-banner-open-url-in-webview-not-closing-banner-different-behaviour-than-ios

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -197,12 +197,14 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
             break;
           }
         }
-      } else if (action.getDismiss()) {
-        appBannerPopup.dismiss();
       } else {
         if (isLastActionElement) {
           appBannerPopup.moveToNextScreen();
         }
+      }
+
+      if (action.getDismiss()) {
+        appBannerPopup.dismiss();
       }
 
       if (action.isOpenBySystem() && action.getUrl() != null && !action.getUrl().isEmpty()) {


### PR DESCRIPTION
If isOpenInWebView is true than dismiss not working.