### PR TITLE
hotfix/CP-8274-if-subscription-id-changed-than-call-confirm-alert

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -1484,13 +1484,11 @@ public class CleverPush {
               }
             }
 
-            if (isSubscriptionChanged()) {
-              if (!isConfirmAlertShown()) {
-                // If the confirm alert has not been tracked by the customer already,
-                // we will track it here retroperspectively to ensure opt-in rate statistics
-                // are correct
-                self.setConfirmAlertShown();
-              }
+            if (isSubscriptionChanged() && !isConfirmAlertShown()) {
+              // If the confirm alert has not been tracked by the customer already,
+              // we will track it here retroperspectively to ensure opt-in rate statistics
+              // are correct
+              self.setConfirmAlertShown();
             }
           }
 

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -1481,13 +1481,15 @@ public class CleverPush {
                     updatePendingTopicsDialog(true);
                   }
                 }
+              }
+            }
 
-                if (!isConfirmAlertShown()) {
-                  // If the confirm alert has not been tracked by the customer already,
-                  // we will track it here retroperspectively to ensure opt-in rate statistics
-                  // are correct
-                  self.setConfirmAlertShown();
-                }
+            if (isSubscriptionChanged()) {
+              if (!isConfirmAlertShown()) {
+                // If the confirm alert has not been tracked by the customer already,
+                // we will track it here retroperspectively to ensure opt-in rate statistics
+                // are correct
+                self.setConfirmAlertShown();
               }
             }
           }
@@ -3516,6 +3518,7 @@ public class CleverPush {
     try {
       subscriptionId = null;
       isSessionStartCalled = false;
+      confirmAlertShown = false;
       SharedPreferences sharedPreferences = getSharedPreferences(getContext());
       SharedPreferences.Editor editor = sharedPreferences.edit();
       editor.remove(CleverPushPreferences.SUBSCRIPTION_ID);


### PR DESCRIPTION
onSuccess of subscribe check if subscription id changed than call confirm-alert API