### PR TITLE
hotfix/CP-8415-android-get-notifications-is-not-updated-anymore

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/service/StoredNotificationsService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/StoredNotificationsService.java
@@ -17,6 +17,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -45,7 +46,7 @@ public class StoredNotificationsService {
     if (notificationsJson != null) {
       try {
         List<Notification> notifications = gson.fromJson(notificationsJson, NotificationList.class);
-        return new HashSet<>(notifications);
+        return new LinkedHashSet<>(notifications);
       } catch (Exception ex) {
         Logger.e(LOG_TAG, "StoredNotificationsService: error while getting stored notifications from local", ex);
       }


### PR DESCRIPTION
Issue is  when convert a List to a HashSet, the order of the elements changed because a HashSet is unordered.

https://github.com/cleverpush/cleverpush-android-sdk/blob/e2c80ff72ff6d589110c0f6a1b288e6254c6899d/cleverpush/src/main/java/com/cleverpush/service/StoredNotificationsService.java#L48

While do the return in `getNotificationsFromLocal` method we convert `List<Notification>` to `HashSet` it changes the order. It removes the oldest element and the new one but because of it changes the order in last element didn't receives the latest one.

A `LinkedHashSet` maintains the insertion order of elements, so the order of notifications in the set will be the same as in the original list.