### PR TITLE
hotfix/CP-9219-android-sdk-subscribed-topics-are-always-needs-to-be-updated

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -1348,6 +1348,7 @@ public class CleverPush {
 
   public void updateServerSessionStart() {
     isSessionStartCalled = true;
+    CleverPush instance = this;
     SharedPreferences sharedPreferences = getSharedPreferences(getContext());
     String fcmToken = sharedPreferences.getString(CleverPushPreferences.FCM_TOKEN, null);
     String lastNotificationId = sharedPreferences.getString(CleverPushPreferences.LAST_NOTIFICATION_ID, null);
@@ -1363,7 +1364,7 @@ public class CleverPush {
     }
 
     CleverPushHttpClient.postWithRetry("/subscription/session/start", jsonBody,
-        new TrackSessionStartResponseHandler().getResponseHandler());
+        new TrackSessionStartResponseHandler(instance).getResponseHandler());
   }
 
   public void increaseSessionVisits() {

--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -39,6 +39,5 @@ public class CleverPushPreferences {
   public static final String SILENT_PUSH_APP_BANNER = "CleverPush_SILENT_PUSH_APP_BANNER";
   public static final String APP_INSTALLATION_DATE = "CleverPush_APP_INSTALLATION_DATE";
   public static final String BANNER_DISPLAY_INTERVAL_DATE = "CleverPush_BANNER_DISPLAY_INTERVAL_DATE";
-  public static final String SUBSCRIPTION_TOPICS_LAST_UPDATED_DATE = "CleverPush_SUBSCRIPTION_TOPICS_LAST_UPDATED_DATE";
 
 }

--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -39,5 +39,6 @@ public class CleverPushPreferences {
   public static final String SILENT_PUSH_APP_BANNER = "CleverPush_SILENT_PUSH_APP_BANNER";
   public static final String APP_INSTALLATION_DATE = "CleverPush_APP_INSTALLATION_DATE";
   public static final String BANNER_DISPLAY_INTERVAL_DATE = "CleverPush_BANNER_DISPLAY_INTERVAL_DATE";
+  public static final String SUBSCRIPTION_TOPICS_LAST_UPDATED_DATE = "CleverPush_SUBSCRIPTION_TOPICS_LAST_UPDATED_DATE";
 
 }

--- a/cleverpush/src/main/java/com/cleverpush/responsehandlers/TrackSessionStartResponseHandler.java
+++ b/cleverpush/src/main/java/com/cleverpush/responsehandlers/TrackSessionStartResponseHandler.java
@@ -2,17 +2,91 @@ package com.cleverpush.responsehandlers;
 
 import static com.cleverpush.Constants.LOG_TAG;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.cleverpush.CleverPush;
+import com.cleverpush.CleverPushPreferences;
 import com.cleverpush.util.Logger;
 
 import com.cleverpush.CleverPushHttpClient;
+import com.cleverpush.util.SharedPreferencesManager;
+
+import org.json.JSONObject;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public class TrackSessionStartResponseHandler {
+  private final CleverPush cleverPush;
+  private static String DEFAULT_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+
+  public TrackSessionStartResponseHandler(CleverPush instance) {
+    this.cleverPush = instance;
+  }
 
   public CleverPushHttpClient.ResponseHandler getResponseHandler() {
     return new CleverPushHttpClient.ResponseHandler() {
       @Override
       public void onSuccess(String response) {
         Logger.d(LOG_TAG, "Session started");
+        if (response != null && !response.isEmpty()) {
+          try {
+            JSONObject jsonResponse = new JSONObject(response);
+            String sdkForceSyncAfter = jsonResponse.optString("sdkForceSyncAfter", null);
+
+            Date forceSyncAfter = null;
+            SimpleDateFormat dateFormatter = new SimpleDateFormat(DEFAULT_DATE_TIME_FORMAT, Locale.US);
+            dateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+            if (sdkForceSyncAfter != null && !sdkForceSyncAfter.isEmpty()) {
+
+              try {
+                forceSyncAfter = dateFormatter.parse(sdkForceSyncAfter);
+              } catch (Exception e) {
+                Logger.e(LOG_TAG, "Failed to parse sdkForceSyncAfter.", e);
+              }
+            }
+
+            SharedPreferences sharedPreferences = getSharedPreferences(getContext());
+            SharedPreferences.Editor editor = sharedPreferences.edit();
+
+            String subscriptionTopicLastUpdatedDateStr = sharedPreferences.getString(
+                    CleverPushPreferences.SUBSCRIPTION_TOPICS_LAST_UPDATED_DATE, null);
+
+            Date subscriptionTopicLastUpdatedDate = null;
+            if (subscriptionTopicLastUpdatedDateStr != null) {
+              try {
+                subscriptionTopicLastUpdatedDate = dateFormatter.parse(subscriptionTopicLastUpdatedDateStr);
+              } catch (Exception e) {
+                Logger.e(LOG_TAG, "Failed to parse subscriptionTopicLastUpdatedDate.", e);
+              }
+            }
+
+            // If no previous update date exists, use the current date
+            Date currentDate = new Date();
+            if (subscriptionTopicLastUpdatedDate == null) {
+              subscriptionTopicLastUpdatedDate = currentDate;
+            }
+
+            // Compare dates and call checkChangedPushToken if needed
+            if (forceSyncAfter != null && forceSyncAfter.after(subscriptionTopicLastUpdatedDate)) {
+              cleverPush.subscribe();
+
+              // Store the **current date and time** in SharedPreferences
+              String currentDateTimeStr = dateFormatter.format(currentDate);
+              editor.putString(CleverPushPreferences.SUBSCRIPTION_TOPICS_LAST_UPDATED_DATE, currentDateTimeStr);
+              editor.apply();
+            } else {
+              Logger.d(LOG_TAG, "No need to check push token. sdkForceSyncAfter is not later than subscriptionTopicLastUpdatedDate.");
+            }
+
+          } catch (Exception e) {
+            Logger.e(LOG_TAG, "TrackSessionStartResponseHandler: Failed to parse sdkForceSyncAfter.", e);
+          }
+        }
       }
 
       @Override
@@ -32,6 +106,14 @@ public class TrackSessionStartResponseHandler {
         }
       }
     };
+  }
+
+  public SharedPreferences getSharedPreferences(Context context) {
+    return SharedPreferencesManager.getSharedPreferences(context);
+  }
+
+  public Context getContext() {
+    return CleverPush.context;
   }
 
 }


### PR DESCRIPTION
Android SDK: Subscribed topics are always needs to be updated

session/start API (will trigger on each app open) -> We could handle the response and if it contains `sdkForceSyncAfter` Date field is NEWER than locally saved version, we'll force a sync.