### PR TITLE
feature/CP-9297-android-native-react-native-sdk-optimizations

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -3659,6 +3659,14 @@ public class CleverPush {
     return !MetaDataUtils.getManifestMetaBoolean(getContext(), "com.cleverpush.notification_open_activity_disabled");
   }
 
+  public int getDefaultNotificationIcon() {
+    return MetaDataUtils.getManifestMetaResourceId(getContext(), "com.cleverpush.default_notification_icon");
+  }
+
+  public int getDefaultNotificationColor() {
+    return MetaDataUtils.getManifestMetaResourceId(getContext(), "com.cleverpush.default_notification_color");
+  }
+
   public void setIgnoreDisabledNotificationPermission(boolean ignore) {
     this.ignoreDisabledNotificationPermission = ignore;
   }

--- a/cleverpush/src/main/java/com/cleverpush/util/MetaDataUtils.java
+++ b/cleverpush/src/main/java/com/cleverpush/util/MetaDataUtils.java
@@ -35,6 +35,14 @@ public class MetaDataUtils {
     return null;
   }
 
+  public static int getManifestMetaResourceId(Context context, String metaName) {
+    Bundle bundle = getManifestMetaBundle(context);
+    if (bundle != null) {
+      return bundle.getInt(metaName, 0);
+    }
+    return 0;
+  }
+
   public static String getChannelId(Context paramContext) {
     ApplicationInfo localApplicationInfo;
     try {


### PR DESCRIPTION
1. set custom sound through category.
2. Can set default notification icon through meta-data `com.cleverpush.default_notification_icon`
3. Can set custom notification color through meta-data `com.cleverpush.default_notification_color`

Customer have suggest the below meta-data
```
<meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/notification_icon"/>
<meta-data android:name="com.google.firebase.messaging.default_notification_color" android:resource="@color/notification_icon_color"/>
```

but we already have one meta-data for push, so i have used the same prefix as below:
`<meta-data android:name="com.cleverpush.notification_open_activity_disabled" android:value="true" />`

when send push through API with soundFilename, it will not work for android because it's only support iOS. To support in android need changes in `cleverpush-pushworker` repo

```
https://api.cleverpush.com/notification/send
{
    "channelId": "zETeJFCgzbcfeLdaJ",
    "title": "Sound test push through API",
    "text": "Sound Test",
    "url": "https://www.google.com",
    "soundFilename": "custom_notification"
}
```
<img width="1497" alt="Screenshot 2025-03-05 at 12 29 02 PM" src="https://github.com/user-attachments/assets/002acd54-b317-45d4-b560-e7a6ccc0b9e8" />

