### PR TITLE
hotfix/CP-9302-android-sdk-forward-user-on-permission-request-to-app-settings

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/chat/ChatJavascriptInterface.java
+++ b/cleverpush/src/main/java/com/cleverpush/chat/ChatJavascriptInterface.java
@@ -1,11 +1,15 @@
 package com.cleverpush.chat;
 
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.provider.Settings;
 import android.webkit.JavascriptInterface;
 
 import com.cleverpush.CleverPush;
 import com.cleverpush.listener.ChatSubscribeListener;
 import com.cleverpush.listener.SubscribedCallbackListener;
+import com.cleverpush.util.Logger;
 
 public class ChatJavascriptInterface {
   private Context context;
@@ -33,7 +37,18 @@ public class ChatJavascriptInterface {
 
         @Override
         public void onFailure(Throwable exception) {
-
+          try {
+            if (exception.getLocalizedMessage().equalsIgnoreCase("Can not subscribe because the notification permission has been denied by the user. " +
+                    "You can call CleverPush.setIgnoreDisabledNotificationPermission(true) to still allow subscriptions, e.g. for silent pushes.")); {
+              Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+              Uri uri = Uri.fromParts("package", context.getPackageName(), null);
+              intent.setData(uri);
+              intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+              context.startActivity(intent);
+            }
+          } catch (Exception e) {
+            Logger.e("CleverPush", "Error while opening app settings: " + e.getMessage(), e);
+          }
         }
       });
     }).start();


### PR DESCRIPTION
If user denied notification permission then on click of Enable Chat View button open app setting.