### PR TITLE
hotfix/cp-9244-in-app-banner-add-string-array-check-to-attribute-targeting

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -672,7 +672,11 @@ public class AppBannerModule {
           }
 
           if (attributeValue == null) {
-            return false;
+            if (CheckFilterRelation.fromString(relationString).equals(CheckFilterRelation.NotContains)) {
+              attributeValue = "";
+            } else {
+              return false;
+            }
           }
 
           if (!this.checkRelationFilter(allowed, CheckFilterRelation.fromString(relationString), attributeValue,


### PR DESCRIPTION
in app banner targeting attribute with not contains is not working.