### PR TITLE
hotfix/cp-9310-android-setmaximumnotificationcount-stores-extra-push

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -2838,7 +2838,8 @@ public class CleverPush {
   }
 
   public void setMaximumNotificationCount(int limit) {
-    NotificationDataProcessor.maximumNotifications = limit;
+    SharedPreferences sharedPreferences = getSharedPreferences(getContext());
+    sharedPreferences.edit().putInt(CleverPushPreferences.MAXIMUM_NOTIFICATION_COUNT, limit).apply();
   }
 
   public void getNotifications(@Deprecated boolean combineWithApi,

--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -41,5 +41,6 @@ public class CleverPushPreferences {
   public static final String BANNER_DISPLAY_INTERVAL_DATE = "CleverPush_BANNER_DISPLAY_INTERVAL_DATE";
   public static final String NOTIFICATION_CHANNEL_UPDATED_AT = "CleverPush_NOTIFICATION_CHANNEL_UPDATED_AT";
   public static final String INCREMENT_BADGE = "CleverPush_INCREMENT_BADGE";
+  public static final String MAXIMUM_NOTIFICATION_COUNT = "CleverPush_MAXIMUM_NOTIFICATION_COUNT";
 
 }

--- a/cleverpush/src/main/java/com/cleverpush/service/NotificationDataProcessor.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/NotificationDataProcessor.java
@@ -113,6 +113,7 @@ public class NotificationDataProcessor {
     }
 
     try {
+      maximumNotifications = sharedPreferences.getInt(CleverPushPreferences.MAXIMUM_NOTIFICATION_COUNT, 100);
       if (maximumNotifications <= 0) {
         return;
       }


### PR DESCRIPTION
When app is killed setMaximumNotificationCount values get ignored.