### PR TITLE
hotfix/cp-9364-in-app-banners-are-not-displayed

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -1349,7 +1349,7 @@ public class AppBannerModule {
                 conditionTrue = this.checkEventTriggerCondition(condition, isMultipleEvent, eventTriggers);
               } else if (condition.getType().equals(BannerTriggerConditionType.Deeplink)) {
                 conditionTrue = this.checkDeeplinkTriggerCondition(condition);
-              } else if (condition.getType().equals(BannerTriggerConditionType.DaysSinceInstallation)) {
+              } else if (condition.getType().equals(BannerTriggerConditionType.DaysSinceInitialization)) {
                 conditionTrue = this.checkDaysSinceInstallationTriggerCondition(condition);
               } else {
                 conditionTrue = false;

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/BannerTriggerConditionType.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/BannerTriggerConditionType.java
@@ -9,7 +9,7 @@ public enum BannerTriggerConditionType {
   Duration,
   Unsubscribe,
   Deeplink,
-  DaysSinceInstallation;
+  DaysSinceInitialization;
 
   private static Map<String, BannerTriggerConditionType> mapTriggerType = new HashMap<>();
 
@@ -19,7 +19,7 @@ public enum BannerTriggerConditionType {
     mapTriggerType.put("duration", BannerTriggerConditionType.Duration);
     mapTriggerType.put("unsubscribe", BannerTriggerConditionType.Unsubscribe);
     mapTriggerType.put("deepLink", BannerTriggerConditionType.Deeplink);
-    mapTriggerType.put("daysSinceInstallation", BannerTriggerConditionType.DaysSinceInstallation);
+    mapTriggerType.put("daysSinceInitialization", BannerTriggerConditionType.DaysSinceInitialization);
   }
 
   public static BannerTriggerConditionType fromString(String raw) {


### PR DESCRIPTION
App banner is not displaying due to BannerTriggerConditionType mismatch.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed in-app banners not displaying by correcting the trigger condition type from DaysSinceInstallation to DaysSinceInitialization.

<!-- End of auto-generated description by cubic. -->

