### PR TITLE
feature/cp-9459-android-add-contains-substring-relation-logic-to-in-app-banner

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/models/CheckFilterRelation.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/CheckFilterRelation.java
@@ -10,7 +10,8 @@ public enum CheckFilterRelation {
   Between,
   NotEqual,
   Contains,
-  NotContains;
+  NotContains,
+  ContainsSubstring;
 
   private static final Map<String, CheckFilterRelation> relations = new HashMap<>();
 
@@ -22,6 +23,7 @@ public enum CheckFilterRelation {
     relations.put("notEquals", CheckFilterRelation.NotEqual);
     relations.put("contains", CheckFilterRelation.Contains);
     relations.put("notContains", CheckFilterRelation.NotContains);
+    relations.put("containsSubstring", CheckFilterRelation.ContainsSubstring);
   }
 
   public static CheckFilterRelation fromString(String raw) {


### PR DESCRIPTION
Add Contains Substring Relation Logic to In-App-Banner Targeting with Attributes
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for a "contains substring" relation in in-app banner targeting, allowing banners to match user attributes that include a specific substring.

- **New Features**
  - Added "containsSubstring" relation to attribute targeting logic.
  - Updated logic to handle both string and array attribute values.

<!-- End of auto-generated description by cubic. -->

