### PR TITLE
feature/cp-9530-android-mobile-sdk-call-the-api-to-track-the-inboxview-clicks

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxView.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxView.java
@@ -148,7 +148,7 @@ public class InboxView extends LinearLayout {
   private void trackInboxNotificationClick(String notificationId) {
     String channelId = getCleverPushInstance().getChannelId(context);
     if (channelId == null) {
-      Logger.w(LOG_TAG, "Channel ID is null. Skipping inbox notification click tracking.");
+      Logger.w(LOG_TAG, "Channel ID is null. Skipping InboxView notification click tracking.");
       return;
     }
 
@@ -157,7 +157,7 @@ public class InboxView extends LinearLayout {
       jsonBody.put("channelId", channelId);
       jsonBody.put("notificationId", notificationId);
     } catch (JSONException e) {
-      Logger.e(LOG_TAG, "Error creating JSON for inbox notification click tracking request.", e);
+      Logger.e(LOG_TAG, "Error creating JSON for InboxView notification click tracking request.", e);
       return;
     }
 
@@ -165,12 +165,12 @@ public class InboxView extends LinearLayout {
     CleverPushHttpClient.postWithRetry(inboxViewClickPath, jsonBody, new CleverPushHttpClient.ResponseHandler() {
       @Override
       public void onSuccess(String response) {
-        Logger.d(LOG_TAG, "Successfully tracked inbox notification click");
+        Logger.d(LOG_TAG, "Successfully tracked InboxView notification click");
       }
 
       @Override
       public void onFailure(int statusCode, String response, Throwable throwable) {
-        Logger.e(LOG_TAG, "Failed to track inbox notification click." +
+        Logger.e(LOG_TAG, "Failed to track InboxView notification click." +
                 "\nStatus code: " + statusCode +
                 "\nResponse: " + response +
                 (throwable != null ? ("\nError: " + throwable.getMessage()) : ""));


### PR DESCRIPTION
Call the API to track InboxView notification clicks.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added API call to track when a user clicks a notification in the InboxView.

- **New Features**
 - Sends a POST request with channel and notification IDs each time a notification is clicked in the inbox.

<!-- End of auto-generated description by cubic. -->

