### PR TITLE
feature/cp-9714-android-ensure-setreadtrue-updates-are-stored-and-reflected

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/Notification.java
+++ b/cleverpush/src/main/java/com/cleverpush/Notification.java
@@ -1,10 +1,12 @@
 package com.cleverpush;
 
+import android.content.SharedPreferences;
 import android.os.Build;
 
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 
+import com.cleverpush.util.SharedPreferencesManager;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.Serializable;
@@ -247,11 +249,35 @@ public class Notification implements Serializable {
   }
 
   public Boolean getRead() {
-    return read;
+    SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(CleverPush.context);
+    String openStoriesString = sharedPreferences.getString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, "");
+
+    if (!openStoriesString.isEmpty()) {
+      if (openStoriesString.contains(this.id)) {
+        return true;
+      } else {
+        return read;
+      }
+    } else {
+      return read;
+    }
   }
 
   public void setRead(Boolean read) {
     this.read = read;
+    if (read) {
+      SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(CleverPush.context);
+      SharedPreferences.Editor editor = sharedPreferences.edit();
+      String preferencesString = sharedPreferences.getString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, "");
+
+      if (preferencesString.isEmpty()) {
+        editor.putString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, this.id).apply();
+      } else {
+        if (!preferencesString.contains(this.id)) {
+          editor.putString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, preferencesString + "," + this.id).apply();
+        }
+      }
+    }
   }
 
   public Boolean getFromApi() {

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxView.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxView.java
@@ -70,11 +70,8 @@ public class InboxView extends LinearLayout {
     getCleverPushInstance().setInitializeListener(new InitializeListener() {
       @Override
       public void onInitialized() {
-        if (getTypedArray().getBoolean(R.styleable.InboxView_combine_with_api, false)) {
-          getNotifications(true);
-        } else {
-          getNotifications(false);
-        }
+        boolean combineWithApi = getTypedArray().getBoolean(R.styleable.InboxView_combine_with_api, false);
+        getNotifications(combineWithApi);
       }
     });
   }

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxView.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxView.java
@@ -152,18 +152,6 @@ public class InboxView extends LinearLayout {
           getCleverPushInstance().getNotificationOpenedListener().notificationOpened(notificationOpenedResult);
         }
 
-        SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(context);
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        String preferencesString = sharedPreferences.getString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, "");
-
-        if (preferencesString.isEmpty()) {
-          editor.putString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, clickedNotification.getId()).apply();
-        } else {
-          if (!preferencesString.contains(clickedNotification.getId())) {
-            editor.putString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, preferencesString + "," + clickedNotification.getId()).apply();
-          }
-        }
-
         getCleverPushInstance().trackInboxNotificationClick(clickedNotification.getId());
         notificationArrayList.get(position).setRead(true);
         inboxViewListAdapter.notifyItemChanged(position, clickedNotification);


### PR DESCRIPTION
Ensure setRead(true) updates are stored and reflected in InboxView
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved the logic for storing and reflecting setRead(true) updates from InboxView to the Notification class, ensuring read status is always saved and shown correctly. 

- **Refactors**
 - Centralized read state management in Notification to prevent inconsistencies.

<!-- End of auto-generated description by cubic. -->

