### PR TITLE
hotfix/cp-9714-android-ensure-setreadtrue-updates-are-stored-and-reflected-v1

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -4327,4 +4327,38 @@ public class CleverPush {
       }
     });
   }
+
+  public void setNotificationRead(Boolean read, String notificationId) {
+    SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(CleverPush.context);
+    SharedPreferences.Editor editor = sharedPreferences.edit();
+    String preferencesString = sharedPreferences.getString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, "");
+
+    if (read) {
+      if (preferencesString.isEmpty()) {
+        editor.putString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, notificationId).apply();
+      } else {
+        if (!preferencesString.contains(notificationId)) {
+          editor.putString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, preferencesString + "," + notificationId).apply();
+        }
+      }
+    } else {
+      if (!preferencesString.isEmpty() && preferencesString.contains(notificationId)) {
+        List<String> ids = new ArrayList<>(Arrays.asList(preferencesString.split(",")));
+        ids.remove(notificationId);
+        String updatedString = String.join(",", ids);
+        editor.putString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, updatedString).apply();
+      }
+    }
+  }
+
+  public Boolean getNotificationRead(String notificationId) {
+    SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(CleverPush.context);
+    String openStoriesString = sharedPreferences.getString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, "");
+
+    if (!openStoriesString.isEmpty()) {
+      return openStoriesString.contains(notificationId);
+    } else {
+      return false;
+    }
+  }
 }

--- a/cleverpush/src/main/java/com/cleverpush/Notification.java
+++ b/cleverpush/src/main/java/com/cleverpush/Notification.java
@@ -249,35 +249,12 @@ public class Notification implements Serializable {
   }
 
   public Boolean getRead() {
-    SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(CleverPush.context);
-    String openStoriesString = sharedPreferences.getString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, "");
-
-    if (!openStoriesString.isEmpty()) {
-      if (openStoriesString.contains(this.id)) {
-        return true;
-      } else {
-        return read;
-      }
-    } else {
-      return read;
-    }
+    return CleverPush.getInstance(CleverPush.context).getNotificationRead(this.id);
   }
 
   public void setRead(Boolean read) {
     this.read = read;
-    if (read) {
-      SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(CleverPush.context);
-      SharedPreferences.Editor editor = sharedPreferences.edit();
-      String preferencesString = sharedPreferences.getString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, "");
-
-      if (preferencesString.isEmpty()) {
-        editor.putString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, this.id).apply();
-      } else {
-        if (!preferencesString.contains(this.id)) {
-          editor.putString(CleverPushPreferences.INBOX_VIEW_NOTIFICATION_OPENED, preferencesString + "," + this.id).apply();
-        }
-      }
-    }
+    CleverPush.getInstance(CleverPush.context).setNotificationRead(read, this.id);
   }
 
   public Boolean getFromApi() {


### PR DESCRIPTION
Optimised the handling of notifications marked as read or unread using setRead()
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved notification read/unread handling on Android so updates made with setRead() are now stored and reflected correctly.

- **Bug Fixes**
 - Centralized read status logic in CleverPush to ensure consistent updates.
 - Fixed issues where marking notifications as read or unread was not reliably saved.

<!-- End of auto-generated description by cubic. -->

