### PR TITLE
feature/cp-9843-android-add-setters-to-storyview-for-flutter-support-without-xml-attributes

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/stories/StoryView.java
+++ b/cleverpush/src/main/java/com/cleverpush/stories/StoryView.java
@@ -49,7 +49,7 @@ public class StoryView extends LinearLayout {
   protected static final int DEFAULT_BACKGROUND_COLOR = Color.WHITE;
   private static final String TAG = "CleverPush/AppStories";
 
-  private TypedArray attrArray;
+  private StoryViewAttributes storyViewAttributes;
   private StoryViewListAdapter storyViewListAdapter;
 
   private Context context;
@@ -59,7 +59,6 @@ public class StoryView extends LinearLayout {
   private String widgetId = null;
   public static StoryView storyView;
   public StoryViewOpenedListener storyViewOpenedListener;
-  private int sortToLastIndex = 0;
   private boolean isDarkModeEnabled = false;
   private boolean hasTrackedStoryShown = false;
 
@@ -73,11 +72,13 @@ public class StoryView extends LinearLayout {
 
   public void setWidgetId(String widgetId) {
     this.widgetId = widgetId;
+    storyViewAttributes.widgetId = widgetId;
     loadStory();
   }
 
   public void setDarkModeEnabled(boolean darkModeEnabled) {
     this.isDarkModeEnabled = darkModeEnabled;
+    storyViewAttributes.darkModeEnabled = darkModeEnabled;
     if (storyViewListAdapter != null) {
       storyViewListAdapter.notifyDataSetChanged();
     }
@@ -90,16 +91,57 @@ public class StoryView extends LinearLayout {
   public StoryView(Context context, AttributeSet attributeSet) {
     super(context, attributeSet);
     this.context = context;
-    attrArray = getContext().obtainStyledAttributes(attributeSet, R.styleable.StoryView);
+    storyViewAttributes = new StoryViewAttributes();
+    TypedArray attrArray = getContext().obtainStyledAttributes(attributeSet, R.styleable.StoryView);
+    initAttributes(attrArray);
     loadStory();
   }
 
+  private void initAttributes(TypedArray attrArray) {
+    storyViewAttributes.backgroundColor = attrArray.getColor(R.styleable.StoryView_background_color, storyViewAttributes.backgroundColor);
+    storyViewAttributes.backgroundColorDarkMode = attrArray.getColor(R.styleable.StoryView_background_color_dark_mode, storyViewAttributes.backgroundColorDarkMode);
+    storyViewAttributes.textColor = attrArray.getColor(R.styleable.StoryView_text_color, storyViewAttributes.textColor);
+    storyViewAttributes.textColorDarkMode = attrArray.getColor(R.styleable.StoryView_text_color_dark_mode, storyViewAttributes.textColorDarkMode);
+    storyViewAttributes.storyViewHeight = getDimensionOrEnum(attrArray, R.styleable.StoryView_story_view_height);
+    storyViewAttributes.storyViewWidth = getDimensionOrEnum(attrArray, R.styleable.StoryView_story_view_width);
+    storyViewAttributes.fontFamily = attrArray.getString(R.styleable.StoryView_font_family);
+    storyViewAttributes.widgetId = attrArray.getString(R.styleable.StoryView_widget_id);
+    storyViewAttributes.titleVisibility = attrArray.getInt(R.styleable.StoryView_title_visibility, storyViewAttributes.titleVisibility);
+    storyViewAttributes.titlePosition = attrArray.getInt(R.styleable.StoryView_title_position, storyViewAttributes.titlePosition);
+    storyViewAttributes.titleTextSize = attrArray.getDimensionPixelSize(R.styleable.StoryView_title_text_size, storyViewAttributes.titleTextSize);
+    storyViewAttributes.titleMinTextSize = attrArray.getDimensionPixelSize(R.styleable.StoryView_title_min_text_size, storyViewAttributes.titleMinTextSize);
+    storyViewAttributes.titleMaxTextSize = attrArray.getDimensionPixelSize(R.styleable.StoryView_title_max_text_size, storyViewAttributes.titleMaxTextSize);
+    storyViewAttributes.storyIconHeight = attrArray.getDimensionPixelSize(R.styleable.StoryView_story_icon_height, storyViewAttributes.storyIconHeight);
+    storyViewAttributes.storyIconHeightPercentage = attrArray.getInt(R.styleable.StoryView_story_icon_height_percentage, storyViewAttributes.storyIconHeightPercentage);
+    storyViewAttributes.storyIconWidth = attrArray.getDimensionPixelSize(R.styleable.StoryView_story_icon_width, storyViewAttributes.storyIconWidth);
+    storyViewAttributes.storyIconCornerRadius = attrArray.getDimension(R.styleable.StoryView_story_icon_corner_radius, storyViewAttributes.storyIconCornerRadius);
+    storyViewAttributes.storyIconSpace = attrArray.getDimension(R.styleable.StoryView_story_icon_space, storyViewAttributes.storyIconSpace);
+    storyViewAttributes.storyIconShadow = attrArray.getBoolean(R.styleable.StoryView_story_icon_shadow, storyViewAttributes.storyIconShadow);
+    storyViewAttributes.borderVisibility = attrArray.getInt(R.styleable.StoryView_border_visibility, storyViewAttributes.borderVisibility);
+    storyViewAttributes.borderMargin = attrArray.getDimension(R.styleable.StoryView_border_margin, storyViewAttributes.borderMargin);
+    storyViewAttributes.borderWidth = attrArray.getDimensionPixelSize(R.styleable.StoryView_border_width, storyViewAttributes.borderWidth);
+    storyViewAttributes.borderColor = attrArray.getColor(R.styleable.StoryView_border_color, storyViewAttributes.borderColor);
+    storyViewAttributes.borderColorDarkMode = attrArray.getColor(R.styleable.StoryView_border_color_dark_mode, storyViewAttributes.borderColorDarkMode);
+    storyViewAttributes.borderColorLoading = attrArray.getColor(R.styleable.StoryView_border_color_loading, storyViewAttributes.borderColorLoading);
+    storyViewAttributes.borderColorLoadingDarkMode = attrArray.getColor(R.styleable.StoryView_border_color_loading_dark_mode, storyViewAttributes.borderColorLoadingDarkMode);
+    storyViewAttributes.subStoryUnreadCountVisibility = attrArray.getInt(R.styleable.StoryView_sub_story_unread_count_visibility, storyViewAttributes.subStoryUnreadCountVisibility);
+    storyViewAttributes.subStoryUnreadCountBackgroundColor = attrArray.getColor(R.styleable.StoryView_sub_story_unread_count_background_color, storyViewAttributes.subStoryUnreadCountBackgroundColor);
+    storyViewAttributes.subStoryUnreadCountBackgroundColorDarkMode = attrArray.getColor(R.styleable.StoryView_sub_story_unread_count_background_color_dark_mode, storyViewAttributes.subStoryUnreadCountBackgroundColorDarkMode);
+    storyViewAttributes.subStoryUnreadCountTextColor = attrArray.getColor(R.styleable.StoryView_sub_story_unread_count_text_color, storyViewAttributes.subStoryUnreadCountTextColor);
+    storyViewAttributes.subStoryUnreadCountTextColorDarkMode = attrArray.getColor(R.styleable.StoryView_sub_story_unread_count_text_color_dark_mode, storyViewAttributes.subStoryUnreadCountTextColorDarkMode);
+    storyViewAttributes.subStoryUnreadCountBadgeHeight = attrArray.getDimensionPixelSize(R.styleable.StoryView_sub_story_unread_count_badge_height, storyViewAttributes.subStoryUnreadCountBadgeHeight);
+    storyViewAttributes.subStoryUnreadCountBadgeWidth = attrArray.getDimensionPixelSize(R.styleable.StoryView_sub_story_unread_count_badge_width, storyViewAttributes.subStoryUnreadCountBadgeWidth);
+    storyViewAttributes.restrictToItems = attrArray.getInt(R.styleable.StoryView_restrict_to_items, storyViewAttributes.restrictToItems);
+    storyViewAttributes.closeButtonPosition = attrArray.getInt(R.styleable.StoryView_close_button_position, storyViewAttributes.closeButtonPosition);
+    storyViewAttributes.sortToLastIndex = attrArray.getInt(R.styleable.StoryView_sort_to_last_index, storyViewAttributes.sortToLastIndex);
+    attrArray.recycle();
+  }
+
   private void loadStory() {
-    String attrWidgetId = attrArray.getString(R.styleable.StoryView_widget_id);
-    if (attrWidgetId == null || attrWidgetId.equalsIgnoreCase("")) {
+    if (storyViewAttributes.widgetId == null || storyViewAttributes.widgetId.equalsIgnoreCase("")) {
       widgetId = getWidgetId();
     } else {
-      widgetId = attrWidgetId;
+      widgetId = storyViewAttributes.widgetId;
     }
 
     if (widgetId == null || widgetId.length() == 0) {
@@ -191,8 +233,7 @@ public class StoryView extends LinearLayout {
             syncUnreadStoryIds();
           }
 
-          sortToLastIndex = attrArray.getInt(R.styleable.StoryView_sort_to_last_index, 0);
-          if (sortToLastIndex == 1) {
+          if (storyViewAttributes.sortToLastIndex == 1) {
             ArrayList<Story> categorizeStories = categorizeStories(stories);
             stories.clear();
             stories.addAll(categorizeStories);
@@ -265,16 +306,15 @@ public class StoryView extends LinearLayout {
       RelativeLayout relativeLayout = view.findViewById(R.id.rlMain);
       RecyclerView recyclerView = view.findViewById(R.id.rvStories);
 
-      relativeLayout.setBackgroundColor(
-          attrArray.getColor(R.styleable.StoryView_background_color, DEFAULT_BACKGROUND_COLOR));
+      relativeLayout.setBackgroundColor(isDarkModeEnabled ? storyViewAttributes.backgroundColorDarkMode : storyViewAttributes.backgroundColor);
       ViewGroup.LayoutParams params = relativeLayout.getLayoutParams();
-      params.height = getDimensionOrEnum(attrArray, R.styleable.StoryView_story_view_height);
-      params.width = getDimensionOrEnum(attrArray, R.styleable.StoryView_story_view_width);
+      params.height = storyViewAttributes.storyViewHeight;
+      params.width = storyViewAttributes.storyViewWidth;
       relativeLayout.setLayoutParams(params);
 
       ViewGroup.LayoutParams recyclerViewParams = recyclerView.getLayoutParams();
-      recyclerViewParams.height = getDimensionOrEnum(attrArray, R.styleable.StoryView_story_view_height);
-      recyclerViewParams.width = getDimensionOrEnum(attrArray, R.styleable.StoryView_story_view_width);
+      recyclerViewParams.height = storyViewAttributes.storyViewHeight;
+      recyclerViewParams.width = storyViewAttributes.storyViewWidth;
       recyclerView.setLayoutParams(recyclerViewParams);
 
       recyclerView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
@@ -286,7 +326,7 @@ public class StoryView extends LinearLayout {
 
           LinearLayoutManager linearLayoutManager =
               new LinearLayoutManager(ActivityLifecycleListener.currentActivity, LinearLayoutManager.HORIZONTAL, false);
-          storyViewListAdapter = new StoryViewListAdapter(ActivityLifecycleListener.currentActivity, stories, attrArray,
+          storyViewListAdapter = new StoryViewListAdapter(ActivityLifecycleListener.currentActivity, stories, storyViewAttributes,
               getOnItemClickListener(stories, recyclerView), recyclerViewWidth, widget.isGroupStoryCategories(), isDarkModeEnabled);
           recyclerView.setLayoutManager(linearLayoutManager);
           recyclerView.setAdapter(storyViewListAdapter);
@@ -308,7 +348,7 @@ public class StoryView extends LinearLayout {
               SharedPreferences.Editor editor = sharedPreferences.edit();
               String preferencesString = sharedPreferences.getString(CleverPushPreferences.APP_OPENED_STORIES, "");
 
-              if (sortToLastIndex == 1) {
+              if (storyViewAttributes.sortToLastIndex == 1) {
                 ArrayList<Story> categorizeStories = categorizeStories(stories);
                 stories.clear();
                 stories.addAll(categorizeStories);
@@ -325,13 +365,11 @@ public class StoryView extends LinearLayout {
 
               int subStoryIndex = calculateSubStoryIndex(sharedPreferences, stories.get(position));
 
-              int closeButtonPosition = attrArray.getInt(R.styleable.StoryView_close_button_position, 0);
-
               if (widget != null && !widget.isGroupStoryCategories()) {
                 stories.get(position).setOpened(true);
               }
               StoryDetailActivity.launch(ActivityLifecycleListener.currentActivity, stories, position, storyViewListAdapter,
-                  closeButtonPosition, subStoryIndex, widgetId, sortToLastIndex, StoryView.this);
+                  storyViewAttributes.closeButtonPosition, subStoryIndex, widgetId, storyViewAttributes.sortToLastIndex, StoryView.this);
               recyclerView.smoothScrollToPosition(position);
             }
           });
@@ -397,7 +435,7 @@ public class StoryView extends LinearLayout {
     this.stories.clear();
     this.stories.addAll(stories);
     if (storyViewListAdapter != null) {
-      if (sortToLastIndex == 1) {
+      if (storyViewAttributes.sortToLastIndex == 1) {
         ArrayList<Story> categorizedStories = categorizeStories(this.stories);
         storyViewListAdapter.updateStories(categorizedStories);
       } else {
@@ -551,4 +589,186 @@ public class StoryView extends LinearLayout {
       Logger.e(TAG, "Error while updating unread story IDs. " + e.getLocalizedMessage(), e);
     }
   }
+
+    public void setBackgroundColor(int color) {
+      storyViewAttributes.backgroundColor = color;
+      refreshStoryView();
+    }
+
+    public void setBackgroundColorDarkMode(int color) {
+      storyViewAttributes.backgroundColorDarkMode = color;
+      refreshStoryView();
+    }
+
+    public void setTextColor(int color) {
+      storyViewAttributes.textColor = color;
+      refreshStoryView();
+    }
+
+    public void setTextColorDarkMode(int color) {
+      storyViewAttributes.textColorDarkMode = color;
+      refreshStoryView();
+    }
+
+    public void setStoryViewHeight(int height) {
+      storyViewAttributes.storyViewHeight = height;
+      refreshStoryView();
+    }
+
+    public void setStoryViewWidth(int width) {
+      storyViewAttributes.storyViewWidth = width;
+      refreshStoryView();
+    }
+
+    public void setFontFamily(String fontFamily) {
+      storyViewAttributes.fontFamily = fontFamily;
+      refreshStoryView();
+    }
+
+    public void setTitleVisibility(int visibility) {
+      storyViewAttributes.titleVisibility = visibility;
+      refreshStoryView();
+    }
+
+    public void setTitlePosition(int position) {
+      storyViewAttributes.titlePosition = position;
+      refreshStoryView();
+    }
+
+    public void setTitleTextSize(int size) {
+      storyViewAttributes.titleTextSize = size;
+      refreshStoryView();
+    }
+
+    public void setTitleMinTextSize(int size) {
+      storyViewAttributes.titleMinTextSize = size;
+      refreshStoryView();
+    }
+
+    public void setTitleMaxTextSize(int size) {
+      storyViewAttributes.titleMaxTextSize = size;
+      refreshStoryView();
+    }
+
+    public void setStoryIconHeight(int height) {
+      storyViewAttributes.storyIconHeight = height;
+      refreshStoryView();
+    }
+
+    public void setStoryIconHeightPercentage(int percentage) {
+      storyViewAttributes.storyIconHeightPercentage = percentage;
+      refreshStoryView();
+    }
+
+    public void setStoryIconWidth(int width) {
+      storyViewAttributes.storyIconWidth = width;
+      refreshStoryView();
+    }
+
+    public void setStoryIconCornerRadius(float radius) {
+      storyViewAttributes.storyIconCornerRadius = radius;
+      refreshStoryView();
+    }
+
+    public void setStoryIconSpace(float space) {
+      storyViewAttributes.storyIconSpace = space;
+      refreshStoryView();
+    }
+
+    public void setStoryIconShadow(boolean shadow) {
+      storyViewAttributes.storyIconShadow = shadow;
+      refreshStoryView();
+    }
+
+    public void setBorderVisibility(int visibility) {
+      storyViewAttributes.borderVisibility = visibility;
+      refreshStoryView();
+    }
+
+    public void setBorderMargin(float margin) {
+      storyViewAttributes.borderMargin = margin;
+      refreshStoryView();
+    }
+
+    public void setBorderWidth(int width) {
+      storyViewAttributes.borderWidth = width;
+      refreshStoryView();
+    }
+
+    public void setBorderColor(int color) {
+      storyViewAttributes.borderColor = color;
+      refreshStoryView();
+    }
+
+    public void setBorderColorDarkMode(int color) {
+      storyViewAttributes.borderColorDarkMode = color;
+      refreshStoryView();
+    }
+
+    public void setBorderColorLoading(int color) {
+      storyViewAttributes.borderColorLoading = color;
+      refreshStoryView();
+    }
+
+    public void setBorderColorLoadingDarkMode(int color) {
+      storyViewAttributes.borderColorLoadingDarkMode = color;
+      refreshStoryView();
+    }
+
+    public void setSubStoryUnreadCountVisibility(int visibility) {
+      storyViewAttributes.subStoryUnreadCountVisibility = visibility;
+      refreshStoryView();
+    }
+
+    public void setSubStoryUnreadCountBackgroundColor(int color) {
+      storyViewAttributes.subStoryUnreadCountBackgroundColor = color;
+      refreshStoryView();
+    }
+
+    public void setSubStoryUnreadCountBackgroundColorDarkMode(int color) {
+      storyViewAttributes.subStoryUnreadCountBackgroundColorDarkMode = color;
+      refreshStoryView();
+    }
+
+    public void setSubStoryUnreadCountTextColor(int color) {
+      storyViewAttributes.subStoryUnreadCountTextColor = color;
+      refreshStoryView();
+    }
+
+    public void setSubStoryUnreadCountTextColorDarkMode(int color) {
+      storyViewAttributes.subStoryUnreadCountTextColorDarkMode = color;
+      refreshStoryView();
+    }
+
+    public void setSubStoryUnreadCountBadgeHeight(int height) {
+      storyViewAttributes.subStoryUnreadCountBadgeHeight = height;
+      refreshStoryView();
+    }
+
+    public void setSubStoryUnreadCountBadgeWidth(int width) {
+      storyViewAttributes.subStoryUnreadCountBadgeWidth = width;
+      refreshStoryView();
+    }
+
+    public void setRestrictToItems(int items) {
+      storyViewAttributes.restrictToItems = items;
+      refreshStoryView();
+    }
+
+    public void setCloseButtonPosition(int position) {
+      storyViewAttributes.closeButtonPosition = position;
+      refreshStoryView();
+    }
+
+    public void setSortToLastIndex(int index) {
+      storyViewAttributes.sortToLastIndex = index;
+      refreshStoryView();
+    }
+
+    private void refreshStoryView() {
+      if (storyViewListAdapter != null) {
+        removeAllViews();
+        displayStoryHead(stories);
+      }
+    }
 }

--- a/cleverpush/src/main/java/com/cleverpush/stories/StoryViewAttributes.java
+++ b/cleverpush/src/main/java/com/cleverpush/stories/StoryViewAttributes.java
@@ -1,0 +1,44 @@
+package com.cleverpush.stories;
+
+import android.graphics.Color;
+import android.view.View;
+
+public class StoryViewAttributes {
+    public int backgroundColor = Color.WHITE;
+    public int backgroundColorDarkMode = Color.WHITE;
+    public int textColor = Color.BLACK;
+    public int textColorDarkMode = Color.BLACK;
+    public int storyViewHeight = -2; // wrap_content
+    public int storyViewWidth = -1; // match_parent
+    public String fontFamily = null;
+    public String widgetId = null;
+    public int titleVisibility = View.VISIBLE;
+    public int titlePosition = 0; // position_default
+    public int titleTextSize = 32;
+    public int titleMinTextSize = 12;
+    public int titleMaxTextSize = 32;
+    public int storyIconHeight = 206;
+    public int storyIconHeightPercentage = 0;
+    public int storyIconWidth = 206;
+    public float storyIconCornerRadius = -1;
+    public float storyIconSpace = -1;
+    public boolean storyIconShadow = false;
+    public int borderVisibility = View.VISIBLE;
+    public float borderMargin = 13.0F;
+    public int borderWidth = 5;
+    public int borderColor = Color.BLACK;
+    public int borderColorDarkMode = Color.BLACK;
+    public int borderColorLoading = Color.BLACK;
+    public int borderColorLoadingDarkMode = Color.BLACK;
+    public int subStoryUnreadCountVisibility = View.GONE;
+    public int subStoryUnreadCountBackgroundColor = Color.BLACK;
+    public int subStoryUnreadCountBackgroundColorDarkMode = Color.BLACK;
+    public int subStoryUnreadCountTextColor = Color.WHITE;
+    public int subStoryUnreadCountTextColorDarkMode = Color.WHITE;
+    public int subStoryUnreadCountBadgeHeight = 78;
+    public int subStoryUnreadCountBadgeWidth = 78;
+    public int restrictToItems = 0;
+    public int closeButtonPosition = 0; // left
+    public int sortToLastIndex = 0; // position_default
+    public boolean darkModeEnabled = false;
+}

--- a/cleverpush/src/main/java/com/cleverpush/stories/StoryViewListAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/stories/StoryViewListAdapter.java
@@ -5,7 +5,6 @@ import static com.cleverpush.stories.StoryView.DEFAULT_BACKGROUND_COLOR;
 import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -57,7 +56,7 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
   private Context context;
   private ArrayList<Story> stories;
   private OnItemClickListener onItemClickListener;
-  private TypedArray typedArray;
+  private StoryViewAttributes storyViewAttributes;
   public static StoryViewListAdapter storyViewListAdapter;
   private int parentLayoutWidth;
   private boolean isGroupStoryCategories;
@@ -65,7 +64,7 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
   boolean isDarkModeEnabled;
   boolean updateView = false;
 
-  public StoryViewListAdapter(Context context, ArrayList<Story> stories, TypedArray typedArray, OnItemClickListener onItemClickListener,
+  public StoryViewListAdapter(Context context, ArrayList<Story> stories, StoryViewAttributes storyViewAttributes, OnItemClickListener onItemClickListener,
                               int parentLayoutWidth, boolean isGroupStoryCategories, boolean isDarkModeEnabled) {
     if (context == null) {
       if (CleverPush.getInstance(CleverPush.context).getCurrentContext() != null) {
@@ -75,7 +74,7 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
       this.context = context;
     }
     this.stories = stories;
-    this.typedArray = typedArray;
+    this.storyViewAttributes = storyViewAttributes;
     this.onItemClickListener = onItemClickListener;
     this.parentLayoutWidth = parentLayoutWidth;
     this.isGroupStoryCategories = isGroupStoryCategories;
@@ -117,33 +116,33 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
       RelativeLayout titleInsideLayout = (RelativeLayout) holder.itemView.findViewById(R.id.titleInsideLayout);
       TextView tvTitleInside = (TextView) holder.itemView.findViewById(R.id.tvTitleInside);
 
-      int iconHeight = (int) typedArray.getDimension(R.styleable.StoryView_story_icon_height, 206);
-      int iconHeightPercentage = typedArray.getInt(R.styleable.StoryView_story_icon_height_percentage, 0);
-      int iconWidth = (int) typedArray.getDimension(R.styleable.StoryView_story_icon_width, 206);
-      boolean iconShadow = typedArray.getBoolean(R.styleable.StoryView_story_icon_shadow, false);
-      int borderVisibility = typedArray.getInt(R.styleable.StoryView_border_visibility, View.VISIBLE);
-      float borderMargin = typedArray.getDimension(R.styleable.StoryView_border_margin, 13.0F);
-      int borderWidth = (int) typedArray.getDimension(R.styleable.StoryView_border_width, 5);
-      float cornerRadius = typedArray.getDimension(R.styleable.StoryView_story_icon_corner_radius, -1);
-      int subStoryUnreadCount = typedArray.getInt(R.styleable.StoryView_sub_story_unread_count_visibility, View.GONE);
-      int restrictToItems = typedArray.getInt(R.styleable.StoryView_restrict_to_items, 0);
-      float iconSpace = typedArray.getDimension(R.styleable.StoryView_story_icon_space, -1);
-      int titlePosition = typedArray.getInt(R.styleable.StoryView_title_position, 0);
-      int titleVisibility = typedArray.getInt(R.styleable.StoryView_title_visibility, View.VISIBLE);
-      int unreadCountBadgeHeight = (int) typedArray.getDimension(R.styleable.StoryView_sub_story_unread_count_badge_height, 78);
-      int unreadCountBadgeWidth = (int) typedArray.getDimension(R.styleable.StoryView_sub_story_unread_count_badge_width, 78);
+      int iconHeight = storyViewAttributes.storyIconHeight;
+      int iconHeightPercentage = storyViewAttributes.storyIconHeightPercentage;
+      int iconWidth = storyViewAttributes.storyIconWidth;
+      boolean iconShadow = storyViewAttributes.storyIconShadow;
+      int borderVisibility = storyViewAttributes.borderVisibility;
+      float borderMargin = storyViewAttributes.borderMargin;
+      int borderWidth = storyViewAttributes.borderWidth;
+      float cornerRadius = storyViewAttributes.storyIconCornerRadius;
+      int subStoryUnreadCount = storyViewAttributes.subStoryUnreadCountVisibility;
+      int restrictToItems = storyViewAttributes.restrictToItems;
+      float iconSpace = storyViewAttributes.storyIconSpace;
+      int titlePosition = storyViewAttributes.titlePosition;
+      int titleVisibility = storyViewAttributes.titleVisibility;
+      int unreadCountBadgeHeight = storyViewAttributes.subStoryUnreadCountBadgeHeight;
+      int unreadCountBadgeWidth = storyViewAttributes.subStoryUnreadCountBadgeWidth;
 
       int storyViewBackgroundColor = 0;
       if (isDarkModeEnabled) {
-        storyViewBackgroundColor = typedArray.getColor(R.styleable.StoryView_background_color_dark_mode, DEFAULT_BACKGROUND_COLOR);
+        storyViewBackgroundColor = storyViewAttributes.backgroundColorDarkMode;
       } else {
-        storyViewBackgroundColor = typedArray.getColor(R.styleable.StoryView_background_color, DEFAULT_BACKGROUND_COLOR);
+        storyViewBackgroundColor = storyViewAttributes.backgroundColor;
       }
       int textColor = 0;
       if (isDarkModeEnabled) {
-        textColor = typedArray.getColor(R.styleable.StoryView_text_color_dark_mode, DEFAULT_TEXT_COLOR);
+        textColor = storyViewAttributes.textColorDarkMode;
       } else {
-        textColor = typedArray.getColor(R.styleable.StoryView_text_color, DEFAULT_TEXT_COLOR);
+        textColor = storyViewAttributes.textColor;
       }
 
       parentLayout.setBackgroundColor(storyViewBackgroundColor);
@@ -193,9 +192,9 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
         }
         int unreadCountTextColor = 0;
         if (isDarkModeEnabled) {
-          unreadCountTextColor = typedArray.getColor(R.styleable.StoryView_sub_story_unread_count_text_color_dark_mode, DEFAULT_UNREAD_COUNT_TEXT_COLOR);
+          unreadCountTextColor = storyViewAttributes.subStoryUnreadCountTextColorDarkMode;
         } else {
-          unreadCountTextColor = typedArray.getColor(R.styleable.StoryView_sub_story_unread_count_text_color, DEFAULT_UNREAD_COUNT_TEXT_COLOR);
+          unreadCountTextColor = storyViewAttributes.subStoryUnreadCountTextColor;
         }
         unreadCountTextView.setTextColor(unreadCountTextColor);
 
@@ -203,9 +202,9 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
         circleDrawable.setShape(GradientDrawable.OVAL);
         int backgroundColor = 0;
         if (isDarkModeEnabled) {
-          backgroundColor = typedArray.getColor(R.styleable.StoryView_sub_story_unread_count_background_color_dark_mode, DEFAULT_UNREAD_COUNT_BACKGROUND_COLOR);;
+          backgroundColor = storyViewAttributes.subStoryUnreadCountBackgroundColorDarkMode;
         } else {
-          backgroundColor = typedArray.getColor(R.styleable.StoryView_sub_story_unread_count_background_color, DEFAULT_UNREAD_COUNT_BACKGROUND_COLOR);
+          backgroundColor = storyViewAttributes.subStoryUnreadCountBackgroundColor;
         }
         circleDrawable.setColor(backgroundColor);
         int unreadCountBorderWidth = 3;
@@ -365,26 +364,26 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
           nameTextViewParams.width = iconWidth;
           nameTextView.setLayoutParams(nameTextViewParams);
 
-          int titleTextSize = typedArray.getDimensionPixelSize(R.styleable.StoryView_title_text_size, 32);
+          int titleTextSize = storyViewAttributes.titleTextSize;
           nameTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX, titleTextSize);
           String titleText = getTitleText(stories, position);
           nameTextView.setText(titleText);
           nameTextView.setTextColor(textColor);
-          applyFont(nameTextView, typedArray);
+          applyFont(nameTextView, storyViewAttributes.fontFamily);
         } else {
           nameTextView.setVisibility(View.GONE);
           titleInsideLayout.setVisibility(View.VISIBLE);
 
-          int titleTextSize = typedArray.getDimensionPixelSize(R.styleable.StoryView_title_text_size, 32);
-          int minTitleTextSize = typedArray.getDimensionPixelSize(R.styleable.StoryView_title_min_text_size, 12);
-          int maxTitleTextSize = typedArray.getDimensionPixelSize(R.styleable.StoryView_title_max_text_size, 32);
+          int titleTextSize = storyViewAttributes.titleTextSize;
+          int minTitleTextSize = storyViewAttributes.titleMinTextSize;
+          int maxTitleTextSize = storyViewAttributes.titleMaxTextSize;
 
           tvTitleInside.setTextSize(TypedValue.COMPLEX_UNIT_PX, titleTextSize);
 
           String titleText = getTitleText(stories, position);
           tvTitleInside.setText(titleText);
           tvTitleInside.setTextColor(textColor);
-          applyFont(tvTitleInside, typedArray);
+          applyFont(tvTitleInside, storyViewAttributes.fontFamily);
 
           // Measure the available width for the title
           int availableWidth = holder.itemView.getWidth() - (tvTitleInside.getPaddingLeft() + tvTitleInside.getPaddingRight());
@@ -501,9 +500,9 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
         border.setColor(0xFFFFFFFF); // White background
         int borderColor = 0;
         if (isDarkModeEnabled) {
-          borderColor = typedArray.getColor(R.styleable.StoryView_border_color_dark_mode, DEFAULT_BORDER_COLOR);
+          borderColor = storyViewAttributes.borderColorDarkMode;
         } else {
-          borderColor = typedArray.getColor(R.styleable.StoryView_border_color, DEFAULT_BORDER_COLOR);
+          borderColor = storyViewAttributes.borderColor;
         }
         border.setStroke(borderWidth, borderColor); // Black or desired border color
       }
@@ -527,15 +526,15 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
     try {
       int DEFAULT_ANIM_COLOR;
       if (isDarkModeEnabled) {
-        DEFAULT_ANIM_COLOR = typedArray.getColor(R.styleable.StoryView_border_color_dark_mode, DEFAULT_BORDER_COLOR);
+        DEFAULT_ANIM_COLOR = storyViewAttributes.borderColorDarkMode;
       } else {
-        DEFAULT_ANIM_COLOR = typedArray.getColor(R.styleable.StoryView_border_color, DEFAULT_BORDER_COLOR);
+        DEFAULT_ANIM_COLOR = storyViewAttributes.borderColor;
       }
       int borderAnimColor;
       if (isDarkModeEnabled) {
-        borderAnimColor = typedArray.getColor(R.styleable.StoryView_border_color_loading_dark_mode, DEFAULT_ANIM_COLOR);
+        borderAnimColor = storyViewAttributes.borderColorLoadingDarkMode;
       } else {
-        borderAnimColor = typedArray.getColor(R.styleable.StoryView_border_color_loading, DEFAULT_ANIM_COLOR);
+        borderAnimColor = storyViewAttributes.borderColorLoading;
       }
 
       GradientDrawable gradientBorder = new GradientDrawable(
@@ -684,12 +683,11 @@ public class StoryViewListAdapter extends RecyclerView.Adapter<StoryViewHolder> 
    * Applies a font to a TextView that uses the "fontPath" attribute.
    *
    * @param textView   TextView when the font should apply
-   * @param typedArray Attributes that contain the "fontPath" attribute with the path to the font file in the assets folder
+   * @param fontPath Attributes that contain the "fontPath" attribute with the path to the font file in the assets folder
    */
-  public void applyFont(TextView textView, TypedArray typedArray) {
-    if (typedArray != null) {
+  public void applyFont(TextView textView, String fontPath) {
+    if (fontPath != null) {
       Context context = textView.getContext();
-      String fontPath = typedArray.getString(R.styleable.StoryView_font_family);
       if (!TextUtils.isEmpty(fontPath)) {
         Typeface typeface = getTypeface(context, fontPath);
         if (typeface != null) {

--- a/cleverpush/src/main/java/com/cleverpush/stories/listener/StoryDetailJavascriptInterface.java
+++ b/cleverpush/src/main/java/com/cleverpush/stories/listener/StoryDetailJavascriptInterface.java
@@ -96,13 +96,15 @@ public class StoryDetailJavascriptInterface {
           if (url != null && !url.isEmpty()) {
             Uri uri = Uri.parse(url);
             StoryDetailActivity.isOpenFromButton = true;
-            if (storyViewOpenedListener != null) {
-              storyViewOpenedListener.opened(uri);
-            } else {
-              if (uri != null) {
-                activity.startActivity(new Intent(Intent.ACTION_VIEW, uri));
+            activity.runOnUiThread(() -> {
+              if (storyViewOpenedListener != null) {
+                storyViewOpenedListener.opened(uri);
+              } else {
+                if (uri != null) {
+                  activity.startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                }
               }
-            }
+            });
           }
         }
       }


### PR DESCRIPTION
Add setters to StoryView for Flutter support without XML attributes
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds runtime setters to StoryView and a StoryViewAttributes model so Flutter can configure stories without XML (CP-9843). Keeps XML support and re-renders on changes.

- New Features
  - Introduced StoryViewAttributes and comprehensive setters for all story UI options (colors, sizes, fonts, titles, borders, unread badge, close button, sorting, widgetId, dark mode).
  - StoryView now refreshes the UI when setters change, enabling live updates without XML.
  - StoryViewListAdapter reads from StoryViewAttributes instead of TypedArray; XML attributes still work for backwards compatibility.

- Bug Fixes
  - Open story button URLs on the UI thread in StoryDetailJavascriptInterface to avoid threading issues.

<!-- End of auto-generated description by cubic. -->

