### PR TITLE
hotfix/cp-9947-android-app-banner-is-not-displaying-correctly

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -252,7 +252,9 @@ public class CleverPush {
       CleverPush.context = context.getApplicationContext();
     }
 
-    sessionListener = initSessionListener();
+    if (!isSessionStartCalled) {
+      sessionListener = initSessionListener();
+    }
 
     if ((Application) getContext() != null) {
       if (context instanceof Activity) {
@@ -610,6 +612,9 @@ public class CleverPush {
       try {
         this.isAppOpen = open;
         if (open) {
+          if (isSessionStartCalled) {
+            return;
+          }
           this.trackSessionStart();
 
           if (this.pendingRequestLocationPermissionCall) {
@@ -644,6 +649,7 @@ public class CleverPush {
             subscribe();
           }
         } else {
+          isSessionStartCalled = false;
           this.trackSessionEnd();
         }
       } catch (Exception e) {
@@ -1352,6 +1358,9 @@ public class CleverPush {
   }
 
   public void updateServerSessionStart() {
+    if (isSessionStartCalled) {
+      return;
+    }
     isSessionStartCalled = true;
     CleverPush instance = this;
     SharedPreferences sharedPreferences = getSharedPreferences(getContext());

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
@@ -68,7 +68,7 @@ public class AppBannerPopup {
   private final int TAB_LAYOUT_DEFAULT_HEIGHT = 48;
   private final int MAIN_LAYOUT_PADDING = 15;
   private final Handler mainHandler;
-  private final Activity activity;
+  private Activity activity;
   private final Banner data;
   private PopupWindow popup;
   private View popupRoot;
@@ -103,6 +103,10 @@ public class AppBannerPopup {
   }
 
   private boolean isRootReady() {
+    boolean isShown = activity.getWindow().getDecorView().isShown();
+    if (!isShown && ActivityLifecycleListener.currentActivity != null) {
+      activity = ActivityLifecycleListener.currentActivity;
+    }
     return activity.getWindow().getDecorView().isShown();
   }
 
@@ -132,6 +136,8 @@ public class AppBannerPopup {
     if (isInitialized) {
       return;
     }
+
+    isRootReady();
 
     int layoutId = R.layout.app_banner;
 


### PR DESCRIPTION
* Resolved an issue with the app banner trigger: durations greater than x seconds are now handled correctly.

* Optimized session increment handling: a session is now increment each time the app is opened.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the Android app banner not showing and ensures session tracking increments once per app open. Addresses Linear CP-9947.

- **Bug Fixes**
  - Recover current Activity if the decor view isn’t shown and verify root readiness before init, so the banner displays reliably.
  - Honor app banner trigger durations longer than X seconds.
  - Guard session start with isSessionStartCalled, gate listener init and server updates, and reset on session end to avoid duplicate starts.

<!-- End of auto-generated description by cubic. -->

