### PR TITLE
hotfix/cp-10088-disableenable-appbanner-not-working-as-expected

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
+++ b/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
@@ -61,7 +61,7 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
 
   @Override
   public void onActivityCreated(Activity activity, Bundle bundle) {
-
+    currentActivity = activity;
   }
 
   @Override

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
@@ -103,8 +103,7 @@ public class AppBannerPopup {
   }
 
   private boolean isRootReady() {
-    boolean isShown = activity.getWindow().getDecorView().isShown();
-    if (!isShown && ActivityLifecycleListener.currentActivity != null) {
+    if (ActivityLifecycleListener.currentActivity != null) {
       activity = ActivityLifecycleListener.currentActivity;
     }
     return activity.getWindow().getDecorView().isShown();


### PR DESCRIPTION
The currentActivity is not being set correctly in ActivityLifecycleListener, which is causing the activity to be null and the banner not to display.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes CP-10088: App banner wasn’t showing after disable/enable because the current activity wasn’t set. We now track the activity correctly and refresh it before checking visibility.

- **Bug Fixes**
  - Set ActivityLifecycleListener.currentActivity in onActivityCreated.
  - In AppBannerPopup.isRootReady, refresh activity from ActivityLifecycleListener before checking decor view visibility.

<!-- End of auto-generated description by cubic. -->

