### PR TITLE
hotfix/cp-9565-android-topic-in-during-opt-in-not-pre-set

### DIFF
--- a/cleverpush-example/src/main/java/com/cleverpush/cleverpush_example_android/MainActivity.java
+++ b/cleverpush-example/src/main/java/com/cleverpush/cleverpush_example_android/MainActivity.java
@@ -27,7 +27,6 @@ public class MainActivity extends AppCompatActivity {
 
         CleverPush.getInstance(this).enableDevelopmentMode();
 //        CleverPush.getInstance(this).setLocalTrackEventRetentionDays(20);
-        CleverPush.getInstance(this).subscribe();
         CleverPush.getInstance(this).init(
                 getString(R.string.channel_id),
                 (NotificationReceivedListener) result -> System.out.println("Received CleverPush Notification: " + result.getNotification().getTitle()),

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -1531,12 +1531,8 @@ public class CleverPush {
               self.trackSessionStart();
             }
 
-            if (subscribedCallbackListener != null) {
-              subscribedCallbackListener.onSuccess(newSubscriptionId);
-            }
-
             if (!isSubscribeForTopicsDialog) {
-              if (newSubscriptionId != null && newSubscription) {
+              if (newSubscriptionId != null && isSubscriptionChanged()) {
                 if (config != null && !config.optBoolean("confirmAlertHideChannelTopics", false)) {
                   JSONArray channelTopics = config.optJSONArray("channelTopics");
                   if (channelTopics != null && channelTopics.length() > 0) {
@@ -1561,6 +1557,10 @@ public class CleverPush {
               // are correct
               self.setConfirmAlertShown();
             }
+
+            if (subscribedCallbackListener != null) {
+              subscribedCallbackListener.onSuccess(newSubscriptionId);
+            }
           }
 
           @Override
@@ -1583,6 +1583,7 @@ public class CleverPush {
     SharedPreferences.Editor editor = sharedPreferences.edit();
     editor.putBoolean(CleverPushPreferences.PENDING_TOPICS_DIALOG, pendingTopicsDialog);
     editor.apply();
+    updateTopicLastCheckedTime();
     CleverPush.instance.showPendingTopicsDialog();
   }
 
@@ -1590,10 +1591,13 @@ public class CleverPush {
     Set<String> selectedTopicIds = new HashSet<>();
     for (int i = 0; i < channelTopics.length(); i++) {
       JSONObject channelTopic = channelTopics.optJSONObject(i);
-      if (channelTopic != null && !channelTopic.optBoolean("defaultUnchecked")) {
-        String id = channelTopic.optString("_id");
-        if (id != null) {
-          selectedTopicIds.add(id);
+      if (channelTopic != null) {
+        boolean defaultUnchecked = channelTopic.optBoolean("defaultUnchecked", false);
+        if (!defaultUnchecked) {
+          String id = channelTopic.optString("_id", "");
+          if (!id.isEmpty()) {
+            selectedTopicIds.add(id);
+          }
         }
       }
     }

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
@@ -130,8 +130,9 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
         try {
           Logger.d(LOG_TAG, "sync response: " + response);
           JSONObject responseJson = new JSONObject(response);
+          String newSubscriptionId = null;
           if (responseJson.has("id")) {
-            String newSubscriptionId = responseJson.getString("id");
+            newSubscriptionId = responseJson.getString("id");
             String oldSubscriptionId = sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ID, null);
             boolean isSubscriptionChanged = !newSubscriptionId.equalsIgnoreCase(oldSubscriptionId);
             CleverPush.getInstance(CleverPush.context).setSubscriptionChanged(isSubscriptionChanged);
@@ -146,7 +147,6 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
             sharedPreferences.edit()
                 .putInt(CleverPushPreferences.SUBSCRIPTION_LAST_SYNC, (int) (System.currentTimeMillis() / 1000L))
                 .apply();
-            subscribedListener.onSuccess(newSubscriptionId);
           }
           if (responseJson.has("topics")) {
             JSONArray topicsArray = responseJson.getJSONArray("topics");
@@ -189,6 +189,10 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
 
             sharedPreferences.edit().putStringSet(CleverPushPreferences.SUBSCRIPTION_TAGS, new HashSet<>(tagIds))
                     .apply();
+          }
+
+          if (newSubscriptionId != null) {
+            subscribedListener.onSuccess(newSubscriptionId);
           }
         } catch (Throwable throwable) {
           Logger.e(LOG_TAG, "Error in syncSubscription request's onSuccess.", throwable);


### PR DESCRIPTION
During opt-in topics are not pre selected in topic dialog
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes missing pre-selected topics in the Android opt-in flow. The topics dialog now respects default selections and only opens when the subscription actually changes (addresses CP-9565).

- **Bug Fixes**
  - Respect defaultUnchecked when building pre-selected topics; ignore empty IDs.
  - Show topics dialog only when isSubscriptionChanged() is true.
  - Call subscribed callback after topics handling and state sync to avoid races.
  - Update last-checked time when marking topics dialog as pending.
  - Example app: remove redundant subscribe() call.

<!-- End of auto-generated description by cubic. -->

