### PR TITLE
feature/cp-10140-app-banner-everyxdays-config

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -1368,7 +1368,7 @@ public class AppBannerModule {
     String currentDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z", Locale.getDefault()).format(new Date());
     intervalDateMap.put(bannerId, currentDate);
     sharedPreferences.edit().putString(CleverPushPreferences.BANNER_DISPLAY_INTERVAL_DATE, new Gson().toJson(intervalDateMap)).apply();
-    return false;
+    return true;
   }
 
   private void updateBannerDisplayDate(String bannerId, Map<String, String> intervalDateMap) {


### PR DESCRIPTION
Added the functionality to display the banner the first time it’s created, and then reappear only after X days.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Shows the app banner immediately on first creation, then only reappears after the configured X-day interval. Addresses Linear CP-10140: every X days banner config.

<!-- End of auto-generated description by cubic. -->

