### PR TITLE
hotfix/cp-10456-android-sdk-app-banner-throws-error-when-trigger-and-target

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -1000,7 +1000,7 @@ public class AppBannerModule {
             }
             currentEventMatches = conditionTrue;
           } else {
-            return false;
+            currentEventMatches = false;
           }
         }
       }


### PR DESCRIPTION
The App-Banner throws an error when the trigger and target use the same event name, where the trigger includes a property, but the target does not include any property.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the Android SDK App Banner when the trigger and target share an event name but only the trigger has properties. Addresses CP-10456 by safely handling events without properties during condition checks.

- **Bug Fixes**
  - Only compare event properties when the event has properties; otherwise treat the condition as not met.
  - In current-event matching, return false for property-based triggers if the event has no properties.

<sup>Written for commit 516a0772ea901a567e20f836b14c06400273c072. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



