### PR TITLE
hotfix/cp-10283-cleverpush-instance-removed-when-app-is-running-listeners

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/service/CleanUpService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/CleanUpService.java
@@ -34,11 +34,20 @@ public class CleanUpService extends Service {
     boolean notificationOpenedActivityWasDestroyedRecently =
         System.currentTimeMillis() - notificationOpenedActivityWasDestroyedAt
             < EXPECTED_NOTIFICATION_OPENED_ACTIVITY_ON_DESTROY_DELAY;
-    if (shouldStartActivity || !notificationOpenedActivityWasDestroyedRecently) {
+
+    boolean appInBackground = false, appInForeground = false;
+    if (ActivityLifecycleListener.getInstance() != null) {
+      appInBackground = ActivityLifecycleListener.getInstance().isAppInBackground();
+      appInForeground = ActivityLifecycleListener.getInstance().isAppOpen();
+    }
+
+    if (!appInBackground && !appInForeground && (shouldStartActivity || !notificationOpenedActivityWasDestroyedRecently)) {
       CleverPush.removeInstance();
     }
 
-    ActivityLifecycleListener.clearSessionListener();
+    if (!appInBackground && !appInForeground) {
+      ActivityLifecycleListener.clearSessionListener();
+    }
     this.stopSelf();
   }
 }


### PR DESCRIPTION
If the app is open, then do not remove the CleverPush instance or clear the session listener.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop removing the CleverPush instance and clearing the session listener while the app is running (foreground or background). Addresses Linear CP-10283 to prevent lost sessions and disabled listeners when the app is open.

- **Bug Fixes**
  - In CleanUpService.onTaskRemoved, use ActivityLifecycleListener state and only remove the instance/clear the session listener when the app is neither in foreground nor background, still honoring the notification opened activity delay.

<sup>Written for commit a722b810fbc5c68b7199b0eb95d7828060def7c8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

