### PR TITLE
Hotfix / CP-10527 - fix trailing spacing

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -16,6 +16,7 @@ import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.util.Base64;
 import android.util.DisplayMetrics;
@@ -377,6 +378,20 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     body.addView(button);
   }
 
+    public static Spanned removeTrailingBlankLines(Spanned spanned) {
+        SpannableStringBuilder ssb = new SpannableStringBuilder(spanned);
+
+        int i = ssb.length() - 1;
+        while (i >= 0 && Character.isWhitespace(ssb.charAt(i))) {
+            i--;
+        }
+
+        if (i < ssb.length() - 1) {
+            ssb.delete(i + 1, ssb.length());
+        }
+
+        return ssb;
+    }
   private void composeTextBlock(LinearLayout body, BannerTextBlock block, int position) {
     @SuppressLint("InflateParams") TextView textView =
         (TextView) activity.getLayoutInflater().inflate(R.layout.app_banner_text, null);
@@ -384,8 +399,9 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     if (block.getHtml() != null && !block.getHtml().isEmpty()) {
       try {
         String replacedHtml = VoucherCodeUtils.replaceVoucherCodeString(block.getHtml(), voucherCode);
-        Spanned formattedText = HtmlCompat.fromHtml(replacedHtml, HtmlCompat.FROM_HTML_MODE_LEGACY);
-        textView.setText(formattedText);
+        Spanned formattedText = HtmlCompat.fromHtml(replacedHtml, HtmlCompat.FROM_HTML_MODE_COMPACT);
+        Spanned cleanedText = removeTrailingBlankLines(formattedText);
+        textView.setText(cleanedText);
       } catch (Exception e) {
         Logger.e(TAG, "Error parsing HTML in composeTextBlock for banner text block", e);
         String fallback = VoucherCodeUtils.replaceVoucherCodeString(block.getText(), voucherCode);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes extra spacing at the end of banner text blocks to reduce gaps between sections in Android in-app banners. Addresses Linear CP-10527.

- **Bug Fixes**
  - Trim trailing whitespace from parsed Spanned text via removeTrailingBlankLines before setting the TextView.
  - Parse HTML with HtmlCompat.FROM_HTML_MODE_COMPACT to avoid unnecessary line breaks.

<sup>Written for commit fc148491180f8fa2358694bc4981a40957a5b247. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parses banner HTML text with COMPACT mode and removes trailing blank lines to eliminate extra spacing.
> 
> - **Banner text rendering (`AppBannerCarouselAdapter`)**:
>   - Switch `HtmlCompat.fromHtml` from `FROM_HTML_MODE_LEGACY` to `FROM_HTML_MODE_COMPACT` for `BannerTextBlock`.
>   - Add `removeTrailingBlankLines(Spanned)` and apply to formatted HTML to trim trailing whitespace/blank lines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc148491180f8fa2358694bc4981a40957a5b247. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->