### PR TITLE
hotfix/cp-10490-android-sdk-issue-while-testing-in-app-banners

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -31,6 +31,7 @@ public class CleverPushPreferences {
   public static final String STORIES_UNREAD_COUNT_GROUP = "CleverPush_STORIES_UNREAD_COUNT_GROUP";
   public static final String SUB_STORY_POSITION = "CleverPush_SUB_STORY_POSITION";
   public static final String APP_BANNER_SHOWING = "CleverPush_APP_BANNER_SHOWING";
+  public static final String APP_BANNER_SHOWING_IN_PROGRESS = "CleverPush_APP_BANNER_SHOWING_IN_PROGRESS";
   public static final String UNSUBSCRIBED = "CleverPush_UNSUBSCRIBED";
   public static final String TOPIC_LAST_CHECKED = "CleverPush_TOPIC_LAST_CHECKED";
   public static final String LAST_TIME_AUTO_SHOWED = "CleverPush_LAST_TIME_AUTO_SHOWED";

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -75,6 +75,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCarouselAdapter.ViewHolder> {
 
@@ -748,7 +750,10 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
                 "</script>\n";
         String htmlWithJs;
         if (lower.contains("</body>")) {
-          htmlWithJs = html.replaceAll("(?i)</body>", jsToInject + "</body>");
+          htmlWithJs = Pattern
+                  .compile("(?i)</body>")
+                  .matcher(html)
+                  .replaceAll(Matcher.quoteReplacement(jsToInject + "</body>"));
         } else if (lower.contains("<body")) {
           htmlWithJs = html + jsToInject;
         } else {

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -123,6 +123,7 @@ public class AppBannerModule {
     handlerThread.start();
     handler = new Handler(handlerThread.getLooper());
     editor.putBoolean(CleverPushPreferences.APP_BANNER_SHOWING, false);
+    editor.putBoolean(CleverPushPreferences.APP_BANNER_SHOWING_IN_PROGRESS, false);
     editor.apply();
   }
 
@@ -1856,7 +1857,8 @@ public class AppBannerModule {
       Banner banner = bannerPopup.getData();
       setAppBannerClosedListener(appBannerClosedListener);
       if (!force) {
-        if (sharedPreferences.getBoolean(CleverPushPreferences.APP_BANNER_SHOWING, false)) {
+        if (sharedPreferences.getBoolean(CleverPushPreferences.APP_BANNER_SHOWING, false)
+            || sharedPreferences.getBoolean(CleverPushPreferences.APP_BANNER_SHOWING_IN_PROGRESS, false)) {
           pendingFilteredBanners.add(bannerPopup);
           Logger.d(TAG, "Skipping Banner " + banner.getId() + " because: A Banner is already on the screen");
           return;
@@ -1904,6 +1906,8 @@ public class AppBannerModule {
 
       bannerPopup.init();
       bannerPopup.show();
+
+      sharedPreferences.edit().putBoolean(CleverPushPreferences.APP_BANNER_SHOWING_IN_PROGRESS, true).apply();
 
       getActivityLifecycleListener().setActivityInitializedListener(new ActivityInitializedListener() {
         @Override
@@ -2006,6 +2010,7 @@ public class AppBannerModule {
         getCleverPushInstance().getAppBannerShownListener().shown(banner);
       }
     } catch (Exception ex) {
+      sharedPreferences.edit().putBoolean(CleverPushPreferences.APP_BANNER_SHOWING_IN_PROGRESS, false).apply();
       Logger.e(TAG, "Error in showBanner. " + ex.getMessage(), ex);
     }
   }
@@ -2014,6 +2019,9 @@ public class AppBannerModule {
     try {
       showBanner(bannerPopup, false, null, null);
     } catch (Exception ex) {
+      try {
+        sharedPreferences.edit().putBoolean(CleverPushPreferences.APP_BANNER_SHOWING_IN_PROGRESS, false).apply();
+      } catch (Exception ignore) { }
       Logger.e(TAG, ex.getMessage(), ex);
     }
   }

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
@@ -215,6 +215,7 @@ public class AppBannerPopup {
     SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(CleverPush.context);
     SharedPreferences.Editor editor = sharedPreferences.edit();
     editor.putBoolean(CleverPushPreferences.APP_BANNER_SHOWING, isShowing);
+    editor.putBoolean(CleverPushPreferences.APP_BANNER_SHOWING_IN_PROGRESS, isShowing);
     editor.apply();
   }
 

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
@@ -66,6 +66,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<InboxDetailBannerCarouselAdapter.ViewHolder> {
 
@@ -475,7 +477,10 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
                 "</script>\n";
         String htmlWithJs;
         if (lower.contains("</body>")) {
-          htmlWithJs = html.replaceAll("(?i)</body>", jsToInject + "</body>");
+          htmlWithJs = Pattern
+                  .compile("(?i)</body>")
+                  .matcher(html)
+                  .replaceAll(Matcher.quoteReplacement(jsToInject + "</body>"));
         } else if (lower.contains("<body")) {
           htmlWithJs = html + jsToInject;
         } else {

--- a/cleverpush/src/main/res/layout/app_banner_html.xml
+++ b/cleverpush/src/main/res/layout/app_banner_html.xml
@@ -15,7 +15,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_default="wrap"
         app:layout_constraintWidth_percent="1" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
fix HTML banner crash and remove deprecated ConstraintLayout attr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents concurrent in-app banner display with a new `APP_BANNER_SHOWING_IN_PROGRESS` flag, fixes HTML banner JS injection using safe regex replacement, and removes a deprecated ConstraintLayout attribute.
> 
> - **App Banner display control**:
>   - Add and use `CleverPushPreferences.APP_BANNER_SHOWING_IN_PROGRESS` to gate showing banners (`AppBannerModule`, `AppBannerPopup`).
>   - Set/reset flag around `showBanner` lifecycle and on exceptions; skip when showing or in-progress.
> - **HTML banner stability**:
>   - Replace `String.replaceAll` with `Pattern/Matcher.replaceAll` + `Matcher.quoteReplacement` when injecting JS before `</body>` in `AppBannerCarouselAdapter` and `InboxDetailBannerCarouselAdapter`.
> - **Layout**:
>   - Remove deprecated `app:layout_constraintWidth_default` from `res/layout/app_banner_html.xml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2085db7aa1c59efdb147d2c9ad58630a286aa582. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crash when rendering HTML app banners and prevent overlapping banner displays. Addresses Linear CP-10490 during in-app banner testing.

- **Bug Fixes**
  - Safely inject JS into HTML by using Pattern/Matcher with quoteReplacement when replacing </body> (updated both carousel adapters).
  - Add APP_BANNER_SHOWING_IN_PROGRESS flag to block concurrent shows; set/reset around the show lifecycle and queue pending banners.
  - Remove deprecated ConstraintLayout attribute from app_banner_html.xml.

<sup>Written for commit 2085db7aa1c59efdb147d2c9ad58630a286aa582. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

