### PR TITLE
hotfix/cp-10693-android-removenotification-is-not-working-as-expected

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -21,6 +21,7 @@ import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.service.notification.StatusBarNotification;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.CheckBox;
@@ -2876,9 +2877,23 @@ public class CleverPush {
             StoredNotificationsService.getNotificationsFromLocal(getSharedPreferences(getContext())));
     int requestId = 0;
     String tag = "";
+    String removedGroupKey = null;
 
     for (int i = 0; i < notifications.size(); i++) {
       if (notificationId.equalsIgnoreCase(notifications.get(i).id)) {
+        try {
+          String groupId;
+          if (notifications.get(i).getCategory() != null) {
+            groupId = notifications.get(i).getCategory().getId();
+          } else {
+            groupId = "default";
+          }
+          removedGroupKey = (groupId != null && !groupId.isEmpty())
+                  ? ("cleverpush_group_" + groupId)
+                  : "cleverpush_group_undefined";
+        } catch (Exception ignore) {
+          removedGroupKey = null;
+        }
         requestId = notifications.get(i).getRequestId();
         tag = notifications.get(i).getTag();
         notifications.remove(i);
@@ -2896,9 +2911,55 @@ public class CleverPush {
             notificationManager.cancel(tag, requestId);
           }
         }
+        removeGroupSummaries(removedGroupKey, tag, requestId);
       } catch (Exception e) {
         Logger.e(LOG_TAG, "Error while removing notification from notification center. " + e.getLocalizedMessage(), e);
       }
+    }
+  }
+
+  private void removeGroupSummaries(String removedNotificationGroupKey, String removedNotificationTag, int removedNotificationId) {
+    try {
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+        StatusBarNotification[] activeStatusBarNotifications = BadgeHelper.getActiveNotifications(context);
+        java.util.Map<String, Integer> groupKeyToChildNotificationCount = new java.util.HashMap<>();
+
+        for (StatusBarNotification statusBarNotification : activeStatusBarNotifications) {
+          if (BadgeHelper.isGroupSummary(statusBarNotification)) {
+            continue;
+          }
+          // Skip counting the just-removed child if the system still reports it as active
+          if (removedNotificationTag != null && statusBarNotification.getTag() != null &&
+                  removedNotificationId != 0 && removedNotificationTag.equals(statusBarNotification.getTag()) &&
+                  removedNotificationId == statusBarNotification.getId()) {
+            continue;
+          }
+          String groupKey = statusBarNotification.getNotification() != null ? statusBarNotification.getNotification().getGroup() : null;
+          if (groupKey == null) {
+            continue;
+          }
+          Integer count = groupKeyToChildNotificationCount.get(groupKey);
+          groupKeyToChildNotificationCount.put(groupKey, count == null ? 1 : count + 1);
+        }
+
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        for (StatusBarNotification statusBarNotification : activeStatusBarNotifications) {
+          if (!BadgeHelper.isGroupSummary(statusBarNotification)) {
+            continue;
+          }
+          String groupKey = statusBarNotification.getNotification() != null ? statusBarNotification.getNotification().getGroup() : null;
+          // If a specific group key is provided, only consider summaries for that group
+          if (removedNotificationGroupKey != null && groupKey != null && !removedNotificationGroupKey.equals(groupKey)) {
+            continue;
+          }
+          int remaining = groupKey != null && groupKeyToChildNotificationCount.get(groupKey) != null ? groupKeyToChildNotificationCount.get(groupKey) : 0;
+          if (remaining == 0 && notificationManager != null) {
+            notificationManager.cancel(statusBarNotification.getTag(), statusBarNotification.getId());
+          }
+        }
+      }
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "Error while cleaning up summary notifications. " + e.getMessage(), e);
     }
   }
 


### PR DESCRIPTION
Fix removeNotification to also clear the group’s summary notification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes notification removal to also clean up group summaries when the last child is deleted.
> 
> - Enhances `removeNotification(...)` to derive a `groupKey` from the notification’s category and pass it to `removeGroupSummaries(...)`
> - Adds `removeGroupSummaries(...)` (Android M+) to count active child notifications via `BadgeHelper.getActiveNotifications(...)` and cancel a group’s summary when no children remain; skips the just-removed child and optionally filters by the provided group key
> - Imports `StatusBarNotification` and adds error handling/logging around cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ce811b988d9b420a129c1dce837433fa906c41a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes removeNotification on Android to clear the group summary when its last child is removed. Addresses CP-10693 and prevents stale summary notifications.

- **Bug Fixes**
  - Derives the group key from the notification category and tracks the removed child’s tag/id.
  - Counts active child notifications via StatusBarNotification, skipping the just-removed child.
  - Cancels the group summary when no children remain (Android M+).

<sup>Written for commit 0ce811b988d9b420a129c1dce837433fa906c41a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

