### PR TITLE
feature/cp-10963-add-bridge-function-in-mobile-sdk-to-send-subscription

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -1003,6 +1003,15 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
         webView.evaluateJavascript(jsCallback, null);
       });
     }
+
+    @JavascriptInterface
+    public void copyToClipboard(String text) {
+      ClipboardManager clipboard = (ClipboardManager) CleverPush.context.getSystemService(Context.CLIPBOARD_SERVICE);
+      if (clipboard != null) {
+        ClipData clip = ClipData.newPlainText("label", text);
+        clipboard.setPrimaryClip(clip);
+      }
+    }
   }
 
   /**
@@ -1016,8 +1025,8 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
       String subscriptionId = cleverPush.getSubscriptionId(CleverPush.context);
       String channelId = cleverPush.getChannelId(CleverPush.context);
       Map<String, Object> context = new LinkedHashMap<>();
-      context.put("subscriptionId", subscriptionId != null ? subscriptionId : null);
-      context.put("channelId", channelId != null ? channelId : null);
+      context.put("subscriptionId", subscriptionId);
+      context.put("channelId", channelId);
       return new Gson().toJson(context);
     } catch (Exception ex) {
       Logger.e(TAG, "Error in getSubscriptionContextJson.", ex);
@@ -1025,15 +1034,6 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
       empty.put("subscriptionId", (Object) null);
       empty.put("channelId", (Object) null);
       return new Gson().toJson(empty);
-    }
-  }
-
-  @JavascriptInterface
-  public void copyToClipboard(String text) {
-    ClipboardManager clipboard = (ClipboardManager) CleverPush.context.getSystemService(Context.CLIPBOARD_SERVICE);
-    if (clipboard != null) {
-      ClipData clip = ClipData.newPlainText("label", text);
-      clipboard.setPrimaryClip(clip);
     }
   }
 

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
@@ -2,6 +2,9 @@ package com.cleverpush.inbox;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -731,6 +734,15 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
         webView.evaluateJavascript(jsCallback, null);
       });
     }
+
+    @JavascriptInterface
+    public void copyToClipboard(String text) {
+      ClipboardManager clipboard = (ClipboardManager) CleverPush.context.getSystemService(Context.CLIPBOARD_SERVICE);
+      if (clipboard != null) {
+        ClipData clip = ClipData.newPlainText("label", text);
+        clipboard.setPrimaryClip(clip);
+      }
+    }
   }
 
   /**
@@ -744,8 +756,8 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
       String subscriptionId = cleverPush.getSubscriptionId(CleverPush.context);
       String channelId = cleverPush.getChannelId(CleverPush.context);
       Map<String, Object> context = new LinkedHashMap<>();
-      context.put("subscriptionId", subscriptionId != null ? subscriptionId : null);
-      context.put("channelId", channelId != null ? channelId : null);
+      context.put("subscriptionId", subscriptionId);
+      context.put("channelId", channelId);
       return new Gson().toJson(context);
     } catch (Exception ex) {
       Logger.e(TAG, "Error in getSubscriptionContextJson.", ex);


### PR DESCRIPTION
Added getSubscriptionContextRequest() in the JS bridge; injected Promise-based getSubscriptionContext in both HTML-block and fullscreen banner scripts in AppBannerCarouselAdapter and InboxDetailBannerCarouselAdapter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebView JS injection and `@JavascriptInterface` surfaces; mistakes in JSON escaping or bridge wiring could break HTML banners or expose unexpected JS-bridge behavior.
> 
> **Overview**
> Adds a new JS-bridge API for banner WebViews to retrieve the current *subscription context* (`subscriptionId`, `channelId`). Both `AppBannerCarouselAdapter` and `InboxDetailBannerCarouselAdapter` now inject `CleverPush.subscriptionContext` on load and provide a Promise-based `CleverPush.getSubscriptionContext()` that is resolved via a new `@JavascriptInterface` method `getSubscriptionContextRequest()`.
> 
> To support async callbacks, `CleverpushInterface` now receives the owning `WebView`, and subscription context JSON generation is centralized in `getSubscriptionContextJson()` (null-safe, iOS-compatible).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a75daaebeb81e268c5bbed3f00944d1e7520ebac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a JS bridge to send subscription context (subscriptionId, channelId) to banner WebViews and exposes a Promise-based CleverPush.getSubscriptionContext, with subscriptionContext preloaded. Fulfills CP-10963 and mirrors iOS behavior.

- **New Features**
  - Added @JavascriptInterface getSubscriptionContextRequest() to resolve the Promise with JSON { subscriptionId, channelId } (null when missing), with safe JSON escaping.
  - Injected CleverPush.getSubscriptionContext and prefilled CleverPush.subscriptionContext in both AppBannerCarouselAdapter and InboxDetailBannerCarouselAdapter (HTML-block and fullscreen banners).

- **Refactors**
  - CleverpushInterface now holds a WebView for UI-thread callbacks; moved copyToClipboard into the bridge and centralized context JSON via getSubscriptionContextJson; removed an unused import.

<sup>Written for commit a75daaebeb81e268c5bbed3f00944d1e7520ebac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

