### PR TITLE
hotfix/cp-10955-app-push-carousel-banner-android-swipe-fehler

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -596,7 +596,8 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
                 isScrolling = true; // Allow vertical scroll
                 v.getParent().requestDisallowInterceptTouchEvent(false);
               } else if (deltaX > touchSlop) {
-                v.getParent().requestDisallowInterceptTouchEvent(true); // Allow horizontal swipe
+                // Let ViewPager handle horizontal swipe so carousel can change pages correctly
+                v.getParent().requestDisallowInterceptTouchEvent(false);
               }
             }
             break;
@@ -633,7 +634,8 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
                 isScrolling = true; // Allow vertical scroll
                 v.getParent().requestDisallowInterceptTouchEvent(false);
               } else if (deltaX > touchSlop) {
-                v.getParent().requestDisallowInterceptTouchEvent(true); // Allow horizontal swipe
+                // Let ViewPager handle horizontal swipe so carousel can change pages correctly
+                v.getParent().requestDisallowInterceptTouchEvent(false);
               }
             }
             break;


### PR DESCRIPTION
Fix carousel swipe: allow ViewPager to handle horizontal swipes so swiping back goes to the previous screen instead of triggering the next action

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Android carousel banner swipe (CP-10955). Let ViewPager handle horizontal swipes so users can swipe back to the previous screen instead of triggering the next action.

<sup>Written for commit 91d35ede35d6b2a4fb50ec02d039fc67627fcc09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

