### PR TITLE
Fix button background color: support #RRGGBBAA (CSS) and avoid breaki…

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/util/ColorUtils.java
+++ b/cleverpush/src/main/java/com/cleverpush/util/ColorUtils.java
@@ -14,11 +14,9 @@ public class ColorUtils {
           "#" + colorStr.charAt(1) + colorStr.charAt(1) + colorStr.charAt(2) + colorStr.charAt(2) + colorStr.charAt(3)
               + colorStr.charAt(3);
     }
-    // Android expects #AARRGGBB (alpha first). If we have #RRGGBBAA (alpha last, e.g. from CSS/web),
-    // convert it. Only convert when Android would see alpha=00 (first 2 digits), so we don't break
-    // Android-style #AARRGGBB with non-zero alpha.
-    if (colorStr != null && colorStr.length() == 9 && colorStr.charAt(0) == '#'
-        && colorStr.substring(1, 3).equals("00")) {
+    // Android expects #AARRGGBB (alpha first). CSS/web uses #RRGGBBAA (alpha last). Convert 9-char
+    // hex from RRGGBBAA to AARRGGBB so red/green/blue are correct (otherwise e.g. red becomes blue).
+    if (colorStr != null && colorStr.length() == 9 && colorStr.charAt(0) == '#') {
       String rr = colorStr.substring(1, 3);
       String gg = colorStr.substring(3, 5);
       String bb = colorStr.substring(5, 7);

--- a/cleverpush/src/main/java/com/cleverpush/util/ColorUtils.java
+++ b/cleverpush/src/main/java/com/cleverpush/util/ColorUtils.java
@@ -14,6 +14,17 @@ public class ColorUtils {
           "#" + colorStr.charAt(1) + colorStr.charAt(1) + colorStr.charAt(2) + colorStr.charAt(2) + colorStr.charAt(3)
               + colorStr.charAt(3);
     }
+    // Android expects #AARRGGBB (alpha first). If we have #RRGGBBAA (alpha last, e.g. from CSS/web),
+    // convert it. Only convert when Android would see alpha=00 (first 2 digits), so we don't break
+    // Android-style #AARRGGBB with non-zero alpha.
+    if (colorStr != null && colorStr.length() == 9 && colorStr.charAt(0) == '#'
+        && colorStr.substring(1, 3).equals("00")) {
+      String rr = colorStr.substring(1, 3);
+      String gg = colorStr.substring(3, 5);
+      String bb = colorStr.substring(5, 7);
+      String aa = colorStr.substring(7, 9);
+      colorStr = "#" + aa + rr + gg + bb;
+    }
     int color = Color.BLACK;
     try {
       color = Color.parseColor(colorStr);

--- a/cleverpush/src/main/java/com/cleverpush/util/ColorUtils.java
+++ b/cleverpush/src/main/java/com/cleverpush/util/ColorUtils.java
@@ -9,20 +9,22 @@ public class ColorUtils {
     if (colorStr != null) {
       colorStr = colorStr.trim();
     }
+
+    // Convert #RGB → #RRGGBB
     if (colorStr != null && colorStr.length() == 4 && colorStr.charAt(0) == '#') {
       colorStr =
-          "#" + colorStr.charAt(1) + colorStr.charAt(1) + colorStr.charAt(2) + colorStr.charAt(2) + colorStr.charAt(3)
-              + colorStr.charAt(3);
+              "#" + colorStr.charAt(1) + colorStr.charAt(1)
+                      + colorStr.charAt(2) + colorStr.charAt(2)
+                      + colorStr.charAt(3) + colorStr.charAt(3);
     }
-    // Android expects #AARRGGBB (alpha first). CSS/web uses #RRGGBBAA (alpha last). Convert 9-char
-    // hex from RRGGBBAA to AARRGGBB so red/green/blue are correct (otherwise e.g. red becomes blue).
+
+    // Convert #RRGGBBAA → #AARRGGBB
     if (colorStr != null && colorStr.length() == 9 && colorStr.charAt(0) == '#') {
-      String rr = colorStr.substring(1, 3);
-      String gg = colorStr.substring(3, 5);
-      String bb = colorStr.substring(5, 7);
+      String rrggbb = colorStr.substring(1, 7);
       String aa = colorStr.substring(7, 9);
-      colorStr = "#" + aa + rr + gg + bb;
+      colorStr = "#" + aa + rrggbb;
     }
+
     int color = Color.BLACK;
     try {
       color = Color.parseColor(colorStr);


### PR DESCRIPTION
…ng #AARRGGBB (Android)

Fixed button background color, support 8-digit hex colors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes button background colors by supporting 3- and 8-digit hex values. Expands `#RGB` to `#RRGGBB` and converts CSS `#RRGGBBAA` to Android `#AARRGGBB` without breaking Android-style values.

- **Bug Fixes**
  - In `com.cleverpush.util.ColorUtils.parseColor`, expand `#RGB` → `#RRGGBB` and convert `#RRGGBBAA` → `#AARRGGBB`.
  - Prevents transparent/incorrect buttons in the Rate the App banner (Linear: CP-11067).

<sup>Written for commit f3b2478f9d5e31306adf46756d0c9725cad69cad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

