### PR TITLE
hotfix/cp-11166-app-push-deeplinks-fail-to-open-after-app-restart-task

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
+++ b/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
@@ -5,9 +5,7 @@ import static com.cleverpush.Constants.LOG_TAG;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.ActivityManager;
 import android.app.Application;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -50,6 +48,8 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
     if (instance == null) {
       instance = new ActivityLifecycleListener(sessionListener);
       application.registerActivityLifecycleCallbacks(instance);
+    } else {
+      ActivityLifecycleListener.sessionListener = sessionListener;
     }
   }
 
@@ -75,12 +75,10 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
     Logger.d(LOG_TAG, "onActivityResumed");
     currentActivity = activity;
 
-    if (!isServiceRunning(CleanUpService.class)) {
-      try {
-        CleverPush.context.startService(new Intent(CleverPush.context, CleanUpService.class));
-      } catch (IllegalStateException illegalStateException) {
-        Logger.e(LOG_TAG, "Error starting CleanUpService.", illegalStateException);
-      }
+    try {
+      CleverPush.context.startService(new Intent(CleverPush.context, CleanUpService.class));
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "Error starting CleanUpService.", e);
     }
 
     if (counter == 0 && sessionListener != null) {
@@ -172,17 +170,9 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
   public static void clearSessionListener() {
     sessionListener = null;
     currentActivity = null;
-    activityInitializedListeners = null;
-  }
-
-  private boolean isServiceRunning(Class<?> serviceClass) {
-    ActivityManager manager = (ActivityManager) CleverPush.context.getSystemService(Context.ACTIVITY_SERVICE);
-    for (ActivityManager.RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
-      if (serviceClass.getName().equals(service.service.getClassName())) {
-        return true;
-      }
+    if (activityInitializedListeners != null) {
+      activityInitializedListeners.clear();
     }
-    return false;
   }
 
   public void setActivityInitializedListener(ActivityInitializedListener activityInitializedListener) {

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -243,6 +243,7 @@ public class CleverPush {
   public boolean isTopicDialogAPICalled = false;
   int appBannerPerDay;
   int appBannerPerSession;
+  public static boolean notificationClickInProgress = false;
 
   public CleverPush(@NonNull Context context) {
     if (context == null) {
@@ -4170,8 +4171,28 @@ public class CleverPush {
     CleverPush.isSubscribeForTopicsDialog = isSubscribeForTopicsDialog;
   }
 
-  public static void removeInstance() {
+  public static boolean isNotificationClickInProgress() {
+    return notificationClickInProgress;
+  }
+
+  public void setNotificationClickInProgress(boolean notificationClickInProgress) {
+    CleverPush.notificationClickInProgress = notificationClickInProgress;
+  }
+
+  /**
+   * Clears the SDK singleton when no notification-open flow is running.
+   *
+   * @return true if the instance was removed; false if there was nothing to remove or a click is in progress.
+   */
+  public static boolean removeInstance() {
+    if (instance == null) {
+      return false;
+    }
+    if (isNotificationClickInProgress()) {
+      return false;
+    }
     instance = null;
+    return true;
   }
 
   public void setInitializeListener(InitializeListener initializeListener) {

--- a/cleverpush/src/main/java/com/cleverpush/NotificationOpenedProcessor.java
+++ b/cleverpush/src/main/java/com/cleverpush/NotificationOpenedProcessor.java
@@ -51,64 +51,69 @@ public class NotificationOpenedProcessor {
       CleverPush cleverPush = CleverPush.getInstance(context);
       String channelId = cleverPush.getChannelId(context);
 
-      cleverPush.trackNotificationClicked(notificationId, subscriptionId, channelId, actionIndex);
-
-      cleverPush.fireNotificationOpenedListener(result);
-
-      if (notification.getAppBanner() != null && notification.getAppBanner().length() > 0
-          && notification.getVoucherCode() != null && notification.getVoucherCode().length() > 0) {
-        HashMap<String, String> currentVoucherCodePlaceholder = new HashMap<>();
-
-        if (cleverPush.getAppBannerModule().getCurrentVoucherCodePlaceholder() != null) {
-          currentVoucherCodePlaceholder = cleverPush.getAppBannerModule().getCurrentVoucherCodePlaceholder();
-        }
-
-        currentVoucherCodePlaceholder.put(notification.getAppBanner(), notification.getVoucherCode());
-        cleverPush.getAppBannerModule().setCurrentVoucherCodePlaceholder(currentVoucherCodePlaceholder);
-      }
-
-      // open launcher activity
-      boolean shouldStartActivity = cleverPush.notificationOpenShouldStartActivity();
-      Logger.d(LOG_TAG, "NotificationOpenedProcessor shouldStartActivity: " + shouldStartActivity);
-
-      boolean appInBackground = false, appInForeground = false, customNotificationActivityEnabled = false;
-      customNotificationActivityEnabled = cleverPush.isCustomNotificationActivityEnabled();
-      if (ActivityLifecycleListener.getInstance() != null) {
-        appInBackground = ActivityLifecycleListener.getInstance().isAppInBackground();
-        appInForeground = ActivityLifecycleListener.getInstance().isAppOpen();
-      }
-
-      if (shouldStartActivity) {
-        if (!customNotificationActivityEnabled) {
-          Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
-          if (launchIntent != null) {
-            launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-            context.startActivity(launchIntent);
-          }
-        } else if (!appInForeground && !appInBackground) {
-          Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
-          if (launchIntent != null) {
-            launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-            context.startActivity(launchIntent);
-          }
-        }
-      }
-
+      cleverPush.setNotificationClickInProgress(true);
       try {
-        boolean autoHandleDeepLink = notification.isAutoHandleDeepLink();
-        String deepLinkURL = result.getNotification().getUrl();
-        if (autoHandleDeepLink && deepLinkURL != null && !deepLinkURL.isEmpty()) {
-          setNotificationDeepLink(deepLinkURL, cleverPush);
-          Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(deepLinkURL));
-          context.startActivity(browserIntent);
-        }
-      } catch (Exception e) {
-        Logger.e(LOG_TAG, "Error while handling auto handle deep link for notification id: " + notificationId, e);
-      }
+        cleverPush.trackNotificationClicked(notificationId, subscriptionId, channelId, actionIndex);
 
-      boolean badgeEnabled = notification.getCategory() == null || !notification.getCategory().getBadgeDisabled();
-      if (badgeEnabled) {
-        BadgeHelper.update(context, cleverPush.getIncrementBadge());
+        cleverPush.fireNotificationOpenedListener(result);
+
+        if (notification.getAppBanner() != null && notification.getAppBanner().length() > 0
+                && notification.getVoucherCode() != null && notification.getVoucherCode().length() > 0) {
+          HashMap<String, String> currentVoucherCodePlaceholder = new HashMap<>();
+
+          if (cleverPush.getAppBannerModule().getCurrentVoucherCodePlaceholder() != null) {
+            currentVoucherCodePlaceholder = cleverPush.getAppBannerModule().getCurrentVoucherCodePlaceholder();
+          }
+
+          currentVoucherCodePlaceholder.put(notification.getAppBanner(), notification.getVoucherCode());
+          cleverPush.getAppBannerModule().setCurrentVoucherCodePlaceholder(currentVoucherCodePlaceholder);
+        }
+
+        // open launcher activity
+        boolean shouldStartActivity = cleverPush.notificationOpenShouldStartActivity();
+        Logger.d(LOG_TAG, "NotificationOpenedProcessor shouldStartActivity: " + shouldStartActivity);
+
+        boolean appInBackground = false, appInForeground = false, customNotificationActivityEnabled = false;
+        customNotificationActivityEnabled = cleverPush.isCustomNotificationActivityEnabled();
+        if (ActivityLifecycleListener.getInstance() != null) {
+          appInBackground = ActivityLifecycleListener.getInstance().isAppInBackground();
+          appInForeground = ActivityLifecycleListener.getInstance().isAppOpen();
+        }
+
+        if (shouldStartActivity) {
+          if (!customNotificationActivityEnabled) {
+            Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+            if (launchIntent != null) {
+              launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+              context.startActivity(launchIntent);
+            }
+          } else if (!appInForeground && !appInBackground) {
+            Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+            if (launchIntent != null) {
+              launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+              context.startActivity(launchIntent);
+            }
+          }
+        }
+
+        try {
+          boolean autoHandleDeepLink = notification.isAutoHandleDeepLink();
+          String deepLinkURL = result.getNotification().getUrl();
+          if (autoHandleDeepLink && deepLinkURL != null && !deepLinkURL.isEmpty()) {
+            setNotificationDeepLink(deepLinkURL, cleverPush);
+            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(deepLinkURL));
+            context.startActivity(browserIntent);
+          }
+        } catch (Exception e) {
+          Logger.e(LOG_TAG, "Error while handling auto handle deep link for notification id: " + notificationId, e);
+        }
+
+        boolean badgeEnabled = notification.getCategory() == null || !notification.getCategory().getBadgeDisabled();
+        if (badgeEnabled) {
+          BadgeHelper.update(context, cleverPush.getIncrementBadge());
+        }
+      } finally {
+        cleverPush.setNotificationClickInProgress(false);
       }
     } catch (Exception e) {
       Logger.e(LOG_TAG, "Error while processing intent for push: " + e.getMessage(), e);

--- a/cleverpush/src/main/java/com/cleverpush/service/CleanUpService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/CleanUpService.java
@@ -2,7 +2,9 @@ package com.cleverpush.service;
 
 import android.app.Service;
 import android.content.Intent;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 
 import androidx.annotation.Nullable;
 
@@ -11,7 +13,8 @@ import com.cleverpush.CleverPush;
 
 public class CleanUpService extends Service {
 
-  private final long EXPECTED_NOTIFICATION_OPENED_ACTIVITY_ON_DESTROY_DELAY = 5000;
+  private static final long EXPECTED_NOTIFICATION_OPENED_ACTIVITY_ON_DESTROY_DELAY = 5000;
+  private static final long CLEANUP_DELAY = 5000;
 
   @Nullable
   @Override
@@ -20,34 +23,56 @@ public class CleanUpService extends Service {
   }
 
   @Override
-  public void onDestroy() {
-    super.onDestroy();
-  }
-
-  @Override
   public void onTaskRemoved(Intent rootIntent) {
     super.onTaskRemoved(rootIntent);
 
-    boolean shouldStartActivity = CleverPush.getInstance(this).notificationOpenShouldStartActivity();
-    long notificationOpenedActivityWasDestroyedAt =
-        CleverPush.getInstance(this).getNotificationOpenedActivityDestroyedAt();
-    boolean notificationOpenedActivityWasDestroyedRecently =
-        System.currentTimeMillis() - notificationOpenedActivityWasDestroyedAt
-            < EXPECTED_NOTIFICATION_OPENED_ACTIVITY_ON_DESTROY_DELAY;
+    ActivityLifecycleListener lifecycleListener = ActivityLifecycleListener.getInstance();
 
-    boolean appInBackground = false, appInForeground = false;
-    if (ActivityLifecycleListener.getInstance() != null) {
-      appInBackground = ActivityLifecycleListener.getInstance().isAppInBackground();
-      appInForeground = ActivityLifecycleListener.getInstance().isAppOpen();
+    // Lifecycle not registered yet (e.g. cold start) — skip cleanup.
+    if (lifecycleListener == null) {
+      stopSelf();
+      return;
     }
 
-    if (!appInBackground && !appInForeground && (shouldStartActivity || !notificationOpenedActivityWasDestroyedRecently)) {
-      CleverPush.removeInstance();
+    boolean isAppOpen = lifecycleListener.isAppOpen();
+    boolean isAppInBackground = lifecycleListener.isAppInBackground();
+
+    // App may still be foreground or not marked background — skip cleanup.
+    if (isAppOpen || !isAppInBackground) {
+      stopSelf();
+      return;
     }
 
-    if (!appInBackground && !appInForeground) {
-      ActivityLifecycleListener.clearSessionListener();
+    CleverPush cleverPush = CleverPush.getInstance(this);
+
+    long destroyedAt = cleverPush.getNotificationOpenedActivityDestroyedAt();
+    boolean destroyedRecently =
+            System.currentTimeMillis() - destroyedAt
+                    < EXPECTED_NOTIFICATION_OPENED_ACTIVITY_ON_DESTROY_DELAY;
+
+    // Skip while notification tap is being processed or NotificationOpenedActivity just finished.
+    if (cleverPush.isNotificationClickInProgress() || destroyedRecently) {
+      stopSelf();
+      return;
     }
-    this.stopSelf();
+
+    // Delay cleanup to avoid racing task removal vs. activity lifecycle.
+    new Handler(Looper.getMainLooper()).postDelayed(() -> {
+      ActivityLifecycleListener listener = ActivityLifecycleListener.getInstance();
+      if (listener == null || listener.isAppOpen()) {
+        return;
+      }
+
+      if (CleverPush.isNotificationClickInProgress()) {
+        return;
+      }
+      // Only clear lifecycle session state if the singleton was actually removed; otherwise we would
+      // leave CleverPush initialized but with a null SessionListener (breaks sync / session).
+      if (CleverPush.removeInstance()) {
+        ActivityLifecycleListener.clearSessionListener();
+      }
+    }, CLEANUP_DELAY);
+
+    stopSelf();
   }
 }


### PR DESCRIPTION
Fix race condition causing deep link failure on cold start

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cold-start race that cleared `CleverPush` during notification taps, causing deep links to fail after app restart (CP-11166). Adds a click-in-progress guard and safer cleanup so deep links open reliably.

- **Bug Fixes**
  - `CleverPush`: added `notificationClickInProgress` flag; `removeInstance()` now returns a boolean and refuses removal while a click is in progress.
  - `NotificationOpenedProcessor`: wraps open flow with click-in-progress set/reset; improves auto deep link handling and error logging; preserves badge updates and launcher activity behavior.
  - `CleanUpService`: defers cleanup by 5s, skips when lifecycle not ready, app not backgrounded, click in progress, or recent activity destroy; only clears session after successful `removeInstance()`; calls `stopSelf()` safely.
  - `ActivityLifecycleListener`: always attempts to start `CleanUpService`; refreshes `sessionListener` on re-register; removes service-running check; clears initialized listeners safely.

<sup>Written for commit 93ba8804cc6b58479125558736bb6fa13e1ace9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

