### PR TITLE
hotfix/cp-11255-cleverpush-sdk-gets-stuck-with-isprocessingaddattributequeue

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/responsehandlers/SetSubscriptionAttributeResponseHandler.java
+++ b/cleverpush/src/main/java/com/cleverpush/responsehandlers/SetSubscriptionAttributeResponseHandler.java
@@ -53,18 +53,25 @@ public class SetSubscriptionAttributeResponseHandler {
 
       @Override
       public void onFailure(int statusCode, String response, Throwable throwable) {
-        if (throwable != null) {
-          Logger.e("CleverPush", "Error setting attribute." +
-                  "\nStatus code: " + statusCode +
-                  "\nResponse: " + response +
-                  "\nError: " + throwable.getMessage()
-                  , throwable
-          );
-        } else {
-          Logger.e("CleverPush", "Error setting attribute." +
-                  "\nStatus code: " + statusCode +
-                  "\nResponse: " + response
-          );
+        try {
+          if (throwable != null) {
+            Logger.e("CleverPush", "Error setting attribute." +
+                    "\nStatus code: " + statusCode +
+                    "\nResponse: " + response +
+                    "\nError: " + throwable.getMessage()
+                    , throwable
+            );
+          } else {
+            Logger.e("CleverPush", "Error setting attribute." +
+                    "\nStatus code: " + statusCode +
+                    "\nResponse: " + response
+            );
+          }
+          if (successCallback != null) {
+            successCallback.run();
+          }
+        } catch (Exception ex) {
+          Logger.e(LOG_TAG, "Error in onFailure of setting subscription attribute", ex);
         }
       }
     };


### PR DESCRIPTION
Fix attribute queue getting stuck on API failure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the subscription attribute queue from getting stuck on API failures by advancing the queue in the failure path. Fixes CP-11255.

- **Bug Fixes**
  - In `SetSubscriptionAttributeResponseHandler.onFailure`, call `successCallback` even on error to continue queue processing.
  - Wrap failure handling in try/catch and improve error logs to avoid handler crashes and ensure cleanup.

<sup>Written for commit ce1d0023181eabf5c8545d2397bcbf37740bbc6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

