### PR TITLE
hotfix/cp-11316-android-ensure-channelid-validation-before-executing-api

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/AddSubscriptionTags.java
+++ b/cleverpush/src/main/java/com/cleverpush/AddSubscriptionTags.java
@@ -80,6 +80,10 @@ public class AddSubscriptionTags implements AddTagCompletedListener {
   }
 
   public void addSubscriptionTag(AddTagCompletedListener addTagCompletedListener, int currentPositionOfTagToAdd) {
+    if (this.channelId == null || this.channelId.isEmpty()) {
+      Logger.w(LOG_TAG, "addSubscriptionTag: Channel ID is null or empty.");
+      return;
+    }
     if (subscriptionId != null && !subscriptionId.isEmpty()) {
       tags = this.getSubscriptionTags();
       if (tags.contains(tagIds[currentPositionOfTagToAdd])) {

--- a/cleverpush/src/main/java/com/cleverpush/AddSubscriptionTags.java
+++ b/cleverpush/src/main/java/com/cleverpush/AddSubscriptionTags.java
@@ -82,8 +82,21 @@ public class AddSubscriptionTags implements AddTagCompletedListener {
   public void addSubscriptionTag(AddTagCompletedListener addTagCompletedListener, int currentPositionOfTagToAdd) {
     if (this.channelId == null || this.channelId.isEmpty()) {
       Logger.w(LOG_TAG, "addSubscriptionTag: Channel ID is null or empty.");
+
+      Exception exception = new IllegalStateException("Channel ID is null or empty.");
+
+      if (addTagCompletedListener != null) {
+        addTagCompletedListener.onFailure(exception);
+      }
+
+      if (completionListener != null) {
+        completionListener.onFailure(exception);
+      }
+
+      this.finished = true;
       return;
     }
+
     if (subscriptionId != null && !subscriptionId.isEmpty()) {
       tags = this.getSubscriptionTags();
       if (tags.contains(tagIds[currentPositionOfTagToAdd])) {

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -690,6 +690,11 @@ public class CleverPush {
   }
 
   public void getChannelConfigFromChannelId(boolean autoRegister, String storedChannelId, String storedSubscriptionId, InitializeListener listener) {
+    if (this.channelId == null || this.channelId.isEmpty()) {
+      Logger.w(LOG_TAG, "getChannelConfigFromChannelId: Channel ID is null or empty.");
+      return;
+    }
+
     CleverPush instance = this;
     String configPath = "/channel/" + this.channelId + "/config";
     if (developmentMode) {
@@ -1364,6 +1369,10 @@ public class CleverPush {
     if (isSessionStartCalled) {
       return;
     }
+    String channelId = getChannelId(getContext());
+    if (isChannelIdInvalid(channelId, "updateServerSessionStart"))
+      return;
+
     isSessionStartCalled = true;
     CleverPush instance = this;
     SharedPreferences sharedPreferences = getSharedPreferences(getContext());
@@ -1372,7 +1381,7 @@ public class CleverPush {
 
     JSONObject jsonBody = new JSONObject();
     try {
-      jsonBody.put("channelId", getChannelId(getContext()));
+      jsonBody.put("channelId", channelId);
       jsonBody.put("subscriptionId", getSubscriptionId(getContext()));
       jsonBody.put("fcmToken", fcmToken);
       jsonBody.put("lastNotificationId", lastNotificationId);
@@ -1406,6 +1415,10 @@ public class CleverPush {
   }
 
   public void updateServerSessionEnd() {
+    String channelId = getChannelId(getContext());
+    if (isChannelIdInvalid(channelId, "updateServerSessionEnd"))
+      return;
+
     SharedPreferences sharedPreferences = getSharedPreferences(getContext());
     String fcmToken = sharedPreferences.getString(CleverPushPreferences.FCM_TOKEN, null);
     long sessionEndedTimestamp = System.currentTimeMillis() / MILLISECONDS_PER_SECOND;
@@ -1413,7 +1426,7 @@ public class CleverPush {
 
     JSONObject jsonBody = new JSONObject();
     try {
-      jsonBody.put("channelId", getChannelId(getContext()));
+      jsonBody.put("channelId", channelId);
       jsonBody.put("subscriptionId", getSubscriptionId(getContext()));
       jsonBody.put("fcmToken", fcmToken);
       jsonBody.put("visits", getSessionVisits());
@@ -1612,11 +1625,15 @@ public class CleverPush {
   }
 
   public void unsubscribe(UnsubscribedListener listener) {
+    String channelId = getChannelId(getContext());
+    if (isChannelIdInvalid(channelId, "unsubscribe"))
+      return;
+
     String subscriptionId = getSubscriptionId(getContext());
     if (subscriptionId != null && !subscriptionId.isEmpty()) {
       JSONObject jsonBody = getJsonObject();
       try {
-        jsonBody.put("channelId", getChannelId(getContext()));
+        jsonBody.put("channelId", channelId);
         jsonBody.put("subscriptionId", subscriptionId);
       } catch (JSONException e) {
         Logger.e(LOG_TAG, "Error creating unsubscribe request parameter", e);
@@ -1690,11 +1707,15 @@ public class CleverPush {
   }
 
   public void stopCampaigns(StopCampaignListener listener) {
+    String channelId = getChannelId(getContext());
+    if (isChannelIdInvalid(channelId, "stopCampaigns"))
+      return;
+
     String subscriptionId = getSubscriptionId(getContext());
     if (subscriptionId != null && !subscriptionId.isEmpty()) {
       JSONObject jsonBody = getJsonObject();
       try {
-        jsonBody.put("channelId", getChannelId(getContext()));
+        jsonBody.put("channelId", channelId);
         jsonBody.put("subscriptionId", subscriptionId);
       } catch (JSONException e) {
         Logger.e(LOG_TAG, "Error creating stopCampaigns request parameter", e);
@@ -2241,6 +2262,10 @@ public class CleverPush {
   }
 
   public void addSubscriptionTopic(String topicId, CompletionFailureListener completionListener) {
+    String channelId = getChannelId(getContext());
+    if (isChannelIdInvalid(channelId, "addSubscriptionTopic"))
+      return;
+
     this.getSubscriptionId(subscriptionId -> {
       if (subscriptionId == null || subscriptionId.isEmpty()) {
         Logger.d(LOG_TAG, "addSubscriptionTopic: There is no subscription for CleverPush SDK.");
@@ -2260,7 +2285,7 @@ public class CleverPush {
 
       JSONObject jsonBody = new JSONObject();
       try {
-        jsonBody.put("channelId", getChannelId(getContext()));
+        jsonBody.put("channelId", channelId);
         jsonBody.put("topicId", topicId);
         jsonBody.put("subscriptionId", subscriptionId);
       } catch (JSONException ex) {
@@ -2296,6 +2321,10 @@ public class CleverPush {
   }
 
   public void removeSubscriptionTopic(String topicId, CompletionFailureListener completionListener) {
+    String channelId = getChannelId(getContext());
+    if (isChannelIdInvalid(channelId, "removeSubscriptionTopic"))
+      return;
+
     this.getSubscriptionId(subscriptionId -> {
       if (subscriptionId == null || subscriptionId.isEmpty()) {
         Logger.d(LOG_TAG, "removeSubscriptionTopic: There is no subscription for CleverPush SDK.");
@@ -2315,7 +2344,7 @@ public class CleverPush {
 
       JSONObject jsonBody = new JSONObject();
       try {
-        jsonBody.put("channelId", getChannelId(getContext()));
+        jsonBody.put("channelId", channelId);
         jsonBody.put("topicId", topicId);
         jsonBody.put("subscriptionId", subscriptionId);
       } catch (JSONException ex) {
@@ -2528,6 +2557,10 @@ public class CleverPush {
 
   public void setSubscriptionTopics(String[] topicIds, CompletionFailureListener completionListener) {
     new Thread(() -> {
+      String channelId = getChannelId(getContext());
+      if (isChannelIdInvalid(channelId, "setSubscriptionTopics"))
+        return;
+
       SharedPreferences sharedPreferences = getSharedPreferences(getContext());
       final int topicsVersion = sharedPreferences.getInt(CleverPushPreferences.SUBSCRIPTION_TOPICS_VERSION, 0) + 1;
 
@@ -2540,7 +2573,7 @@ public class CleverPush {
               topicsArray.put(topicId);
             }
 
-            jsonBody.put("channelId", getChannelId(getContext()));
+            jsonBody.put("channelId", channelId);
             jsonBody.put("topics", topicsArray);
             jsonBody.put("topicsVersion", topicsVersion);
             jsonBody.put("subscriptionId", subscriptionId);
@@ -2615,11 +2648,15 @@ public class CleverPush {
   }
 
   private void setSubscriptionAttributeObjectImplementation(String attributeId, Object value, SetSubscriptionAttributeResponseHandler responseHandler) {
+    String channelId = getChannelId(getContext());
+    if (isChannelIdInvalid(channelId, "setSubscriptionAttribute"))
+      return;
+
     this.getSubscriptionId(subscriptionId -> {
       if (subscriptionId != null && !subscriptionId.isEmpty()) {
         JSONObject jsonBody = getJsonObject();
         try {
-          jsonBody.put("channelId", getChannelId(getContext()));
+          jsonBody.put("channelId", channelId);
           jsonBody.put("attributeId", attributeId);
           if (value instanceof String) {
             jsonBody.put("value", value);
@@ -2720,10 +2757,14 @@ public class CleverPush {
 
   public void pushSubscriptionAttributeValue(String attributeId, String value) {
     this.waitForTrackingConsent(() -> new Thread(() -> this.getSubscriptionId(subscriptionId -> {
+      String channelId = getChannelId(getContext());
+      if (isChannelIdInvalid(channelId, "pushSubscriptionAttributeValue"))
+        return;
+
       if (subscriptionId != null && !subscriptionId.isEmpty()) {
         JSONObject jsonBody = new JSONObject();
         try {
-          jsonBody.put("channelId", this.channelId);
+          jsonBody.put("channelId", channelId);
           jsonBody.put("attributeId", attributeId);
           jsonBody.put("value", value);
           jsonBody.put("subscriptionId", subscriptionId);
@@ -2799,10 +2840,14 @@ public class CleverPush {
 
   public void pullSubscriptionAttributeValue(String attributeId, String value) {
     this.waitForTrackingConsent(() -> new Thread(() -> this.getSubscriptionId(subscriptionId -> {
+      String channelId = getChannelId(getContext());
+      if (isChannelIdInvalid(channelId, "pullSubscriptionAttributeValue"))
+        return;
+
       if (subscriptionId != null && !subscriptionId.isEmpty()) {
         JSONObject jsonBody = new JSONObject();
         try {
-          jsonBody.put("channelId", this.channelId);
+          jsonBody.put("channelId", channelId);
           jsonBody.put("attributeId", attributeId);
           jsonBody.put("value", value);
           jsonBody.put("subscriptionId", subscriptionId);
@@ -3073,6 +3118,10 @@ public class CleverPush {
         return;
       }
 
+      String channelId = getChannelId(getContext());
+      if (isChannelIdInvalid(channelId, "trackEvent"))
+        return;
+
       try {
         JSONArray channelEvents = channelConfig.getJSONArray("channelEvents");
         JSONObject event = null;
@@ -3104,7 +3153,7 @@ public class CleverPush {
                   }
                 }
 
-                jsonBody.put("channelId", this.channelId);
+                jsonBody.put("channelId", channelId);
                 jsonBody.put("eventId", eventId);
                 jsonBody.put("properties", propertiesObject);
                 jsonBody.put("subscriptionId", subscriptionId);
@@ -3170,6 +3219,10 @@ public class CleverPush {
   public void triggerFollowUpEvent(String eventName, Map<String, String> parameters) {
     this.waitForTrackingConsent(() -> {
       try {
+        String channelId = getChannelId(getContext());
+        if (isChannelIdInvalid(channelId, "triggerFollowUpEvent"))
+          return;
+
         this.getSubscriptionId(subscriptionId -> {
           if (subscriptionId != null && !subscriptionId.isEmpty()) {
             JSONObject jsonParameters = new JSONObject();
@@ -3185,7 +3238,7 @@ public class CleverPush {
 
             JSONObject jsonBody = new JSONObject();
             try {
-              jsonBody.put("channelId", this.channelId);
+              jsonBody.put("channelId", channelId);
               jsonBody.put("name", eventName);
               jsonBody.put("parameters", jsonParameters);
               jsonBody.put("subscriptionId", subscriptionId);
@@ -3230,6 +3283,9 @@ public class CleverPush {
   }
 
   public void trackNotificationClicked(String notificationId, String subscriptionId, String channelId, String actionIndex) {
+    if (isChannelIdInvalid(channelId, "trackNotificationClicked"))
+      return;
+
     JSONObject jsonBody = new JSONObject();
     try {
       jsonBody.put("notificationId", notificationId);
@@ -3273,6 +3329,10 @@ public class CleverPush {
    * This method may be called by the customer to ensure opt-in rates get calculated correctly.
    */
   public void setConfirmAlertShown() {
+    String channelId = getChannelId(getContext());
+    if (isChannelIdInvalid(channelId, "setConfirmAlertShown"))
+      return;
+
     confirmAlertShown = true;
 
     JSONObject jsonBody = new JSONObject();
@@ -4528,5 +4588,13 @@ public class CleverPush {
     } else {
       return false;
     }
+  }
+
+  private boolean isChannelIdInvalid(String channelId, String methodName) {
+    if (channelId == null || channelId.isEmpty()) {
+      Logger.w(LOG_TAG, methodName + ": Channel ID is null or empty.");
+      return true;
+    }
+    return false;
   }
 }

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -3283,6 +3283,9 @@ public class CleverPush {
   }
 
   public void trackNotificationClicked(String notificationId, String subscriptionId, String channelId, String actionIndex) {
+    if (channelId == null || channelId.isEmpty()) {
+      channelId = getChannelId(getContext());
+    }
     if (isChannelIdInvalid(channelId, "trackNotificationClicked"))
       return;
 

--- a/cleverpush/src/main/java/com/cleverpush/GeofenceBroadcastReceiver.java
+++ b/cleverpush/src/main/java/com/cleverpush/GeofenceBroadcastReceiver.java
@@ -84,7 +84,7 @@ public class GeofenceBroadcastReceiver extends BroadcastReceiver {
         public void onFinish() {
           if (transition == Geofence.GEOFENCE_TRANSITION_ENTER || transition == Geofence.GEOFENCE_TRANSITION_EXIT) {
             List<Geofence> triggeringGeofence = geofencingEvent.getTriggeringGeofences();
-            if (channelId != null && subscriptionId != null && geoFenceIndex < triggeringGeofence.size()) {
+            if (channelId != null && !channelId.isEmpty() && subscriptionId != null && !subscriptionId.isEmpty() && geoFenceIndex < triggeringGeofence.size()) {
               JSONObject jsonBody = new JSONObject();
               try {
                 jsonBody.put("geoFenceId", triggeringGeofence.get(geoFenceIndex).getRequestId());

--- a/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionAttributes.java
+++ b/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionAttributes.java
@@ -81,6 +81,10 @@ public class RemoveSubscriptionAttributes implements RemoveAttributeCompletedLis
       }
       return;
     }
+    if (this.channelId == null || this.channelId.isEmpty()) {
+      Logger.w(LOG_TAG, "removeSubscriptionAttribute: Channel ID is null or empty.");
+      return;
+    }
     if (subscriptionId != null && !subscriptionId.isEmpty()) {
       JSONObject jsonBody = getJsonObject();
       try {

--- a/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionAttributes.java
+++ b/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionAttributes.java
@@ -83,6 +83,10 @@ public class RemoveSubscriptionAttributes implements RemoveAttributeCompletedLis
     }
     if (this.channelId == null || this.channelId.isEmpty()) {
       Logger.w(LOG_TAG, "removeSubscriptionAttribute: Channel ID is null or empty.");
+      if (onRemoveAttributeCompleted != null) {
+        onRemoveAttributeCompleted.onFailure(
+                new IllegalStateException("Channel ID is null or empty."));
+      }
       return;
     }
     if (subscriptionId != null && !subscriptionId.isEmpty()) {

--- a/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionTags.java
+++ b/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionTags.java
@@ -87,13 +87,11 @@ public class RemoveSubscriptionTags implements RemoveTagCompletedListener {
 
       if (onRemoveTagCompleted != null) {
         onRemoveTagCompleted.onFailure(exception);
-      }
-
-      if (completionListener != null) {
+      } else if (completionListener != null) {
         completionListener.onFailure(exception);
       }
-
       this.finished = true;
+
       return;
     }
     if (subscriptionId != null && !subscriptionId.isEmpty()) {

--- a/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionTags.java
+++ b/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionTags.java
@@ -82,6 +82,18 @@ public class RemoveSubscriptionTags implements RemoveTagCompletedListener {
   public void removeSubscriptionTag(RemoveTagCompletedListener onRemoveTagCompleted, int currentPositionOfTagToRemove) {
     if (this.channelId == null || this.channelId.isEmpty()) {
       Logger.w(LOG_TAG, "removeSubscriptionTag: Channel ID is null or empty.");
+
+      Exception exception = new IllegalStateException("Channel ID is null or empty.");
+
+      if (onRemoveTagCompleted != null) {
+        onRemoveTagCompleted.onFailure(exception);
+      }
+
+      if (completionListener != null) {
+        completionListener.onFailure(exception);
+      }
+
+      this.finished = true;
       return;
     }
     if (subscriptionId != null && !subscriptionId.isEmpty()) {

--- a/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionTags.java
+++ b/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionTags.java
@@ -80,6 +80,10 @@ public class RemoveSubscriptionTags implements RemoveTagCompletedListener {
   }
 
   public void removeSubscriptionTag(RemoveTagCompletedListener onRemoveTagCompleted, int currentPositionOfTagToRemove) {
+    if (this.channelId == null || this.channelId.isEmpty()) {
+      Logger.w(LOG_TAG, "removeSubscriptionTag: Channel ID is null or empty.");
+      return;
+    }
     if (subscriptionId != null && !subscriptionId.isEmpty()) {
       JSONObject jsonBody = getJsonObject();
       try {

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -197,6 +197,11 @@ public class AppBannerModule {
   }
 
   synchronized void loadBanners(String notificationId, String channelId) {
+    if (channelId == null || channelId.isEmpty()) {
+      Logger.w(TAG, "loadBanners: Channel ID is null or empty.");
+      return;
+    }
+
     if (isLoading()) {
       if (notificationId != null) {
         pendingBannerAPI.add(notificationId);
@@ -370,6 +375,10 @@ public class AppBannerModule {
                                          String blockId, String screenId, boolean isElementAlreadyClicked, boolean isScreenAlreadyShown) {
     JSONObject jsonBody = getJsonObject();
     try {
+      if (this.channel == null || this.channel.isEmpty()) {
+        Logger.w(TAG, "sendBannerEvent: Channel ID is null or empty.");
+        return;
+      }
       jsonBody.put("bannerId", banner.getId());
       if (banner.getTestId() != null) {
         jsonBody.put("testId", banner.getTestId());
@@ -380,7 +389,7 @@ public class AppBannerModule {
       if (screenId != null && !screenId.isEmpty()) {
         jsonBody.put("screenId", screenId);
       }
-      jsonBody.put("channelId", channel);
+      jsonBody.put("channelId", this.channel);
       jsonBody.put("subscriptionId", subscriptionId);
 
       if (event.equalsIgnoreCase("clicked")) {

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailActivity.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailActivity.java
@@ -5,7 +5,6 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -35,7 +34,6 @@ import androidx.viewpager2.widget.ViewPager2;
 import com.cleverpush.ActivityLifecycleListener;
 import com.cleverpush.CleverPush;
 import com.cleverpush.CleverPushHttpClient;
-import com.cleverpush.CleverPushPreferences;
 import com.cleverpush.Notification;
 import com.cleverpush.R;
 import com.cleverpush.banner.models.Banner;
@@ -49,7 +47,6 @@ import com.cleverpush.listener.AppBannersListener;
 import com.cleverpush.util.ColorUtils;
 import com.cleverpush.util.CustomExceptionHandler;
 import com.cleverpush.util.Logger;
-import com.cleverpush.util.SharedPreferencesManager;
 import com.cleverpush.util.VoucherCodeUtils;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
@@ -216,8 +213,6 @@ public class InboxDetailActivity extends AppCompatActivity {
 
     setOpenedListener(action -> {
       try {
-//            sendBannerEvent("clicked", bannerPopup.getData());
-
         if (getCleverPushInstance().getAppBannerOpenedListener() != null) {
           getCleverPushInstance().getAppBannerOpenedListener().opened(action);
         }
@@ -446,6 +441,11 @@ public class InboxDetailActivity extends AppCompatActivity {
   }
 
   void loadBanners(String notificationId, String channelId) {
+    if (channelId == null || channelId.isEmpty()) {
+      Logger.w(TAG, "InboxView loadBanners: Channel ID is null or empty.");
+      return;
+    }
+
     if (isLoading()) {
       return;
     }

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
@@ -56,8 +56,8 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
     String channelId = sharedPreferences.getString(CleverPushPreferences.CHANNEL_ID, null);
     String subscriptionId = sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ID, null);
     String deviceId = sharedPreferences.getString(CleverPushPreferences.DEVICE_ID, null);
-    if (channelId == null) {
-      Logger.d(LOG_TAG, "channelId in preferences not found");
+    if (channelId == null || channelId.isEmpty()) {
+      Logger.w(LOG_TAG, "syncSubscription: Channel ID is null or empty.");
       return;
     }
 

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
@@ -56,8 +56,12 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
     String channelId = sharedPreferences.getString(CleverPushPreferences.CHANNEL_ID, null);
     String subscriptionId = sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ID, null);
     String deviceId = sharedPreferences.getString(CleverPushPreferences.DEVICE_ID, null);
-    if (channelId == null || channelId.isEmpty()) {
+    if (channelId == null || channelId.trim().isEmpty()) {
       Logger.w(LOG_TAG, "syncSubscription: Channel ID is null or empty.");
+      if (subscribedListener != null) {
+        subscribedListener.onFailure(
+                new IllegalStateException("Channel ID is null or empty."));
+      }
       return;
     }
 

--- a/cleverpush/src/main/java/com/cleverpush/service/CleverPushGeofenceTransitionsIntentService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/CleverPushGeofenceTransitionsIntentService.java
@@ -44,22 +44,30 @@ public class CleverPushGeofenceTransitionsIntentService extends IntentService {
     String channelId = sharedPreferences.getString(CleverPushPreferences.CHANNEL_ID, null);
     String subscriptionId = sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ID, null);
     String transitionState =
-        event.getGeofenceTransition() == Geofence.GEOFENCE_TRANSITION_ENTER ? GEOFENCE_ENTER_STATE :
-            GEOFENCE_EXIT_STATE;
+            event.getGeofenceTransition() == Geofence.GEOFENCE_TRANSITION_ENTER ? GEOFENCE_ENTER_STATE :
+                    GEOFENCE_EXIT_STATE;
 
-    if (channelId != null && subscriptionId != null) {
-      for (Geofence geofence : event.getTriggeringGeofences()) {
-        JSONObject jsonBody = new JSONObject();
-        try {
-          jsonBody.put("geoFenceId", geofence.getRequestId());
-          jsonBody.put("channelId", channelId);
-          jsonBody.put("subscriptionId", subscriptionId);
-          jsonBody.put("state", transitionState);
+    if (channelId == null || channelId.isEmpty()) {
+      Logger.w(LOG_TAG, "geo-fence: Channel ID is null or empty.");
+      return;
+    }
 
-          CleverPushHttpClient.postWithRetry("/subscription/geo-fence", jsonBody, null);
-        } catch (JSONException e) {
-          Logger.e(LOG_TAG, "Error generating geo-fence json", e);
-        }
+    if (subscriptionId == null || subscriptionId.isEmpty()) {
+      Logger.w(LOG_TAG, "geo-fence: Subscription ID is null or empty.");
+      return;
+    }
+
+    for (Geofence geofence : event.getTriggeringGeofences()) {
+      JSONObject jsonBody = new JSONObject();
+      try {
+        jsonBody.put("geoFenceId", geofence.getRequestId());
+        jsonBody.put("channelId", channelId);
+        jsonBody.put("subscriptionId", subscriptionId);
+        jsonBody.put("state", transitionState);
+
+        CleverPushHttpClient.postWithRetry("/subscription/geo-fence", jsonBody, null);
+      } catch (JSONException e) {
+        Logger.e(LOG_TAG, "Error generating geo-fence json", e);
       }
     }
   }

--- a/cleverpush/src/main/java/com/cleverpush/service/StoredNotificationsService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/StoredNotificationsService.java
@@ -81,6 +81,11 @@ public class StoredNotificationsService {
                                                      int limit, int skip,
                                                      NotificationFromApiCallbackListener notificationFromApiCallbackListener,
                                                      NotificationsCallbackListener notificationsCallbackListener) {
+    if (channelId == null || channelId.isEmpty()) {
+      Logger.w(LOG_TAG, "getReceivedNotificationsFromApi: Channel ID is null or empty.");
+      return;
+    }
+
     StringBuilder url =
             new StringBuilder("/channel/" + channelId + "/received-notifications?limit=" + limit + "&skip=" + skip);
     ArrayList<String> subscriptionTopics =

--- a/cleverpush/src/main/java/com/cleverpush/service/StoredNotificationsService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/StoredNotificationsService.java
@@ -83,6 +83,15 @@ public class StoredNotificationsService {
                                                      NotificationsCallbackListener notificationsCallbackListener) {
     if (channelId == null || channelId.isEmpty()) {
       Logger.w(LOG_TAG, "getReceivedNotificationsFromApi: Channel ID is null or empty.");
+
+      if (notificationFromApiCallbackListener != null) {
+        notificationFromApiCallbackListener.ready(new ArrayList<>());
+      }
+
+      if (notificationsCallbackListener != null) {
+        notificationsCallbackListener.ready(new LinkedHashSet<>());
+      }
+
       return;
     }
 


### PR DESCRIPTION
Added a validation to ensure APIs are only executed when a valid channelId is available. If channelId is missing or null, skip the API execution and provide a log

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure all Android SDK API calls only run with a valid channelId. If channelId is null or empty, skip the call and log a warning. Aligns with Linear CP-11316.

- **Bug Fixes**
  - Added `isChannelIdInvalid(...)` in `CleverPush` and guarded session start/end, unsubscribe, `stopCampaigns`, topics add/remove/set, subscription attributes set/push/pull, events, follow-ups, notification clicks, confirm alert, and channel config fetch.
  - Validated channelId in banners: `AppBannerModule.loadBanners/sendBannerEvent` and `InboxDetailActivity.loadBanners`.
  - Hardened geofence reporting in `GeofenceBroadcastReceiver` and `CleverPushGeofenceTransitionsIntentService` (also checks `subscriptionId`, rejects empty IDs).
  - Added checks in `AddSubscriptionTags`, `RemoveSubscriptionTags`, `RemoveSubscriptionAttributes`, `SubscriptionManagerBase.syncSubscription`, and `StoredNotificationsService.getReceivedNotificationsFromApi`; failures now notify listeners (or return empty results) with an `IllegalStateException`.
  - Minor cleanup: reused local `channelId` in JSON bodies and standardized warning logs.

<sup>Written for commit 4b585afad9809d499fec0b9bbcb8435bf1ad8daf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

