### PR TITLE
feature/cp-11109-android-implement-method-for-marking-subscription-as-test

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -79,6 +79,7 @@ import com.cleverpush.mapper.Mapper;
 import com.cleverpush.mapper.SubscriptionToListMapper;
 import com.cleverpush.responsehandlers.ChannelConfigFromBundleIdResponseHandler;
 import com.cleverpush.responsehandlers.ChannelConfigFromChannelIdResponseHandler;
+import com.cleverpush.responsehandlers.MarkSubscriptionAsTestResponseHandler;
 import com.cleverpush.responsehandlers.SetSubscriptionAttributeResponseHandler;
 import com.cleverpush.responsehandlers.SetSubscriptionTopicsResponseHandler;
 import com.cleverpush.responsehandlers.StopCampaignResponseHandler;
@@ -2319,7 +2320,6 @@ public class CleverPush {
         jsonBody.put("topicId", topicId);
         jsonBody.put("subscriptionId", subscriptionId);
       } catch (JSONException ex) {
-
         Logger.e(LOG_TAG, "Error creating removeSubscriptionTopic request parameter", ex);
       }
       CleverPushHttpClient.ResponseHandler responseHandler =
@@ -4531,6 +4531,10 @@ public class CleverPush {
   }
 
   public void markSubscriptionAsTest() {
+    markSubscriptionAsTest(null);
+  }
+
+  public void markSubscriptionAsTest(CompletionFailureListener listener) {
     try {
       String channelId = getChannelId(context);
       if (channelId == null || channelId.isEmpty()) {
@@ -4549,20 +4553,12 @@ public class CleverPush {
       jsonBody.put("subscriptionId", subscriptionId);
 
       String markAsTestPath = "/subscription/mark-as-test";
-      CleverPushHttpClient.postWithRetry(markAsTestPath, jsonBody, new CleverPushHttpClient.ResponseHandler() {
-        @Override
-        public void onSuccess(String response) {
-          Logger.d(LOG_TAG, "markSubscriptionAsTest: Successfully marked subscription as test");
-        }
 
-        @Override
-        public void onFailure(int statusCode, String response, Throwable throwable) {
-          Logger.e(LOG_TAG, "markSubscriptionAsTest: Failed to mark subscription as test." +
-                  "\nStatus code: " + statusCode +
-                  "\nResponse: " + response +
-                  (throwable != null ? ("\nError: " + throwable.getMessage()) : ""));
-        }
-      });
+      CleverPushHttpClient.ResponseHandler responseHandler =
+              new MarkSubscriptionAsTestResponseHandler().getResponseHandler(listener);
+      CleverPushHttpClient.postWithRetry(markAsTestPath,
+              jsonBody,
+              responseHandler);
     } catch (Exception e) {
       Logger.e(LOG_TAG, "markSubscriptionAsTest: Error while marking subscription as test", e);
     }

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -4529,4 +4529,42 @@ public class CleverPush {
       return false;
     }
   }
+
+  public void markSubscriptionAsTest() {
+    try {
+      String channelId = getChannelId(context);
+      if (channelId == null || channelId.isEmpty()) {
+        Logger.w(LOG_TAG, "markSubscriptionAsTest: Channel ID is null");
+        return;
+      }
+
+      String subscriptionId = getSubscriptionId(getContext());
+      if (subscriptionId == null || subscriptionId.isEmpty()) {
+        Logger.w(LOG_TAG, "markSubscriptionAsTest: There is no subscriptionId");
+        return;
+      }
+
+      JSONObject jsonBody = new JSONObject();
+      jsonBody.put("channelId", channelId);
+      jsonBody.put("subscriptionId", subscriptionId);
+
+      String markAsTestPath = "/subscription/mark-as-test";
+      CleverPushHttpClient.postWithRetry(markAsTestPath, jsonBody, new CleverPushHttpClient.ResponseHandler() {
+        @Override
+        public void onSuccess(String response) {
+          Logger.d(LOG_TAG, "markSubscriptionAsTest: Successfully marked subscription as test");
+        }
+
+        @Override
+        public void onFailure(int statusCode, String response, Throwable throwable) {
+          Logger.e(LOG_TAG, "markSubscriptionAsTest: Failed to mark subscription as test." +
+                  "\nStatus code: " + statusCode +
+                  "\nResponse: " + response +
+                  (throwable != null ? ("\nError: " + throwable.getMessage()) : ""));
+        }
+      });
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "markSubscriptionAsTest: Error while marking subscription as test", e);
+    }
+  }
 }

--- a/cleverpush/src/main/java/com/cleverpush/responsehandlers/MarkSubscriptionAsTestResponseHandler.java
+++ b/cleverpush/src/main/java/com/cleverpush/responsehandlers/MarkSubscriptionAsTestResponseHandler.java
@@ -1,0 +1,46 @@
+package com.cleverpush.responsehandlers;
+
+import static com.cleverpush.Constants.LOG_TAG;
+
+import com.cleverpush.CleverPushHttpClient;
+import com.cleverpush.listener.CompletionFailureListener;
+import com.cleverpush.util.Logger;
+
+public class MarkSubscriptionAsTestResponseHandler {
+
+  public CleverPushHttpClient.ResponseHandler getResponseHandler(CompletionFailureListener completionListener) {
+    return new CleverPushHttpClient.ResponseHandler() {
+
+      @Override
+      public void onSuccess(String response) {
+        Logger.d(LOG_TAG, "markSubscriptionAsTest: Successfully marked subscription as test");
+        if (completionListener != null) {
+          completionListener.onComplete();
+        }
+      }
+
+      @Override
+      public void onFailure(int statusCode, String response, Throwable throwable) {
+
+        String errorMessage = "markSubscriptionAsTest: Failed to mark subscription as test." +
+                "\nStatus code: " + statusCode +
+                "\nResponse: " + response;
+
+        if (throwable != null) {
+          errorMessage += "\nError: " + throwable.getMessage();
+          Logger.e(LOG_TAG, errorMessage, throwable);
+
+          if (completionListener != null) {
+            completionListener.onFailure(new Exception(errorMessage, throwable));
+          }
+        } else {
+          Logger.e(LOG_TAG, errorMessage);
+
+          if (completionListener != null) {
+            completionListener.onFailure(new Exception(errorMessage));
+          }
+        }
+      }
+    };
+  }
+}


### PR DESCRIPTION
Added method `markSubscriptionAsTest` to mark subscription as test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CP-11109 by adding `markSubscriptionAsTest()` and an overload with `CompletionFailureListener` to flag the current Android subscription as a test. Posts to `/subscription/mark-as-test` via `CleverPushHttpClient.postWithRetry` using `MarkSubscriptionAsTestResponseHandler`, with channel/subscription ID checks and callback-based success/error handling.

<sup>Written for commit 34add1a032e43a219f320107c3346eb362ca9fa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

