### PR TITLE
feature/cp-11109-android-implement-method-for-marking-subscription-as-test

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -4614,6 +4614,38 @@ public class CleverPush {
     }
   }
 
+  public void markSubscriptionAsTest() {
+    markSubscriptionAsTest(null);
+  }
+
+  public void markSubscriptionAsTest(CompletionFailureListener listener) {
+    try {
+      String channelId = getChannelId(context);
+      if (isChannelIdInvalid(channelId, "markSubscriptionAsTest"))
+        return;
+
+      String subscriptionId = getSubscriptionId(getContext());
+      if (subscriptionId == null || subscriptionId.isEmpty()) {
+        Logger.w(LOG_TAG, "markSubscriptionAsTest: There is no subscriptionId");
+        return;
+      }
+
+      JSONObject jsonBody = new JSONObject();
+      jsonBody.put("channelId", channelId);
+      jsonBody.put("subscriptionId", subscriptionId);
+
+      String markAsTestPath = "/subscription/mark-as-test";
+
+      CleverPushHttpClient.ResponseHandler responseHandler =
+              new MarkSubscriptionAsTestResponseHandler().getResponseHandler(listener);
+      CleverPushHttpClient.postWithRetry(markAsTestPath,
+              jsonBody,
+              responseHandler);
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "markSubscriptionAsTest: Error while marking subscription as test", e);
+    }
+  }
+
   private boolean isChannelIdInvalid(String channelId, String methodName) {
     if (channelId == null || channelId.isEmpty()) {
       Logger.w(LOG_TAG, methodName + ": Channel ID is null or empty.");

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -79,6 +79,7 @@ import com.cleverpush.mapper.Mapper;
 import com.cleverpush.mapper.SubscriptionToListMapper;
 import com.cleverpush.responsehandlers.ChannelConfigFromBundleIdResponseHandler;
 import com.cleverpush.responsehandlers.ChannelConfigFromChannelIdResponseHandler;
+import com.cleverpush.responsehandlers.MarkSubscriptionAsTestResponseHandler;
 import com.cleverpush.responsehandlers.SetSubscriptionAttributeResponseHandler;
 import com.cleverpush.responsehandlers.SetSubscriptionTopicsResponseHandler;
 import com.cleverpush.responsehandlers.StopCampaignResponseHandler;
@@ -2349,7 +2350,6 @@ public class CleverPush {
         jsonBody.put("topicId", topicId);
         jsonBody.put("subscriptionId", subscriptionId);
       } catch (JSONException ex) {
-
         Logger.e(LOG_TAG, "Error creating removeSubscriptionTopic request parameter", ex);
       }
       CleverPushHttpClient.ResponseHandler responseHandler =

--- a/cleverpush/src/main/java/com/cleverpush/responsehandlers/MarkSubscriptionAsTestResponseHandler.java
+++ b/cleverpush/src/main/java/com/cleverpush/responsehandlers/MarkSubscriptionAsTestResponseHandler.java
@@ -1,0 +1,46 @@
+package com.cleverpush.responsehandlers;
+
+import static com.cleverpush.Constants.LOG_TAG;
+
+import com.cleverpush.CleverPushHttpClient;
+import com.cleverpush.listener.CompletionFailureListener;
+import com.cleverpush.util.Logger;
+
+public class MarkSubscriptionAsTestResponseHandler {
+
+  public CleverPushHttpClient.ResponseHandler getResponseHandler(CompletionFailureListener completionListener) {
+    return new CleverPushHttpClient.ResponseHandler() {
+
+      @Override
+      public void onSuccess(String response) {
+        Logger.d(LOG_TAG, "markSubscriptionAsTest: Successfully marked subscription as test");
+        if (completionListener != null) {
+          completionListener.onComplete();
+        }
+      }
+
+      @Override
+      public void onFailure(int statusCode, String response, Throwable throwable) {
+
+        String errorMessage = "markSubscriptionAsTest: Failed to mark subscription as test." +
+                "\nStatus code: " + statusCode +
+                "\nResponse: " + response;
+
+        if (throwable != null) {
+          errorMessage += "\nError: " + throwable.getMessage();
+          Logger.e(LOG_TAG, errorMessage, throwable);
+
+          if (completionListener != null) {
+            completionListener.onFailure(new Exception(errorMessage, throwable));
+          }
+        } else {
+          Logger.e(LOG_TAG, errorMessage);
+
+          if (completionListener != null) {
+            completionListener.onFailure(new Exception(errorMessage));
+          }
+        }
+      }
+    };
+  }
+}


### PR DESCRIPTION
Added method `markSubscriptionAsTest` to mark subscription as test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Android API to mark the current subscription as a test, fulfilling CP-11109. Provides an overload with an optional `CompletionFailureListener` and a response handler for clear success/failure reporting.

- **New Features**
  - Added `CleverPush.markSubscriptionAsTest()` and `markSubscriptionAsTest(CompletionFailureListener)`.
  - Posts `channelId` and `subscriptionId` to `/subscription/mark-as-test`.
  - Introduced `MarkSubscriptionAsTestResponseHandler` to log outcomes and invoke `onComplete`/`onFailure`.
  - Validates presence of `channelId` and `subscriptionId` and exits early if missing.

<sup>Written for commit 7f0cca32d6ff673e283f24f3d958d6b583ee0bf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

