### PR TITLE
hotfix/cp-11369-android-fcm-token-retrieval-fails-on-latest-firebase-flutter

### DIFF
--- a/cleverpush-example/google-services.json
+++ b/cleverpush-example/google-services.json
@@ -1,34 +1,78 @@
 {
   "project_info": {
-    "project_number": "255590593470",
-    "project_id": "cp-test-33927",
-    "storage_bucket": "cp-test-33927.firebasestorage.app"
+    "project_number": "698395861632",
+    "firebase_url": "https://cp-test-91df0.firebaseio.com",
+    "project_id": "cp-test-91df0",
+    "storage_bucket": "cp-test-91df0.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:255590593470:android:9f7bcdcc3cf568ab5bffef",
+        "mobilesdk_app_id": "1:698395861632:android:dfd1ac953d27fe34d97c65",
+        "android_client_info": {
+          "package_name": "com.capacitorjs.app.testapp"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.cleverpush.example"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:698395861632:android:1c5982891be00936d97c65",
         "android_client_info": {
           "package_name": "com.cleverpush.cleverpush_example_android"
         }
       },
       "oauth_client": [
         {
-          "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
+          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDGvNCGExEWzsc55yNyL2MxYCxpdqUScww"
+          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
         }
       ],
       "services": {
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
+              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
               "client_type": 3
+            },
+            {
+              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.cleverpush.example"
+              }
             }
           ]
         }
@@ -36,36 +80,79 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "1:255590593470:android:726d6e4582024ed85bffef",
+        "mobilesdk_app_id": "1:698395861632:android:3b57669b41491a3d",
+        "android_client_info": {
+          "package_name": "com.cleverpush.cleverpushandroidtest"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "698395861632-6sld9g424e3lv976s67g7t9vqimt63dd.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.cleverpush.cleverpushandroidtest",
+            "certificate_hash": "9160aadd9c2971ce85482790fa47f3ba10ddd059"
+          }
+        },
+        {
+          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.cleverpush.example"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:698395861632:android:a1e66fd0cf4de302d97c65",
         "android_client_info": {
           "package_name": "com.cleverpush.example"
         }
       },
       "oauth_client": [
         {
-          "client_id": "255590593470-n58f4v5mlu1hovvc9vs157saaavmolp7.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.cleverpush.example",
-            "certificate_hash": "d398826b29ee3556a90cb9e3caf04c8173ddad9b"
-          }
-        },
-        {
-          "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
+          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDGvNCGExEWzsc55yNyL2MxYCxpdqUScww"
+          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
         }
       ],
       "services": {
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
+              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
               "client_type": 3
+            },
+            {
+              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.cleverpush.example"
+              }
             }
           ]
         }
@@ -73,28 +160,187 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "1:255590593470:android:28f928ca672e7d365bffef",
+        "mobilesdk_app_id": "1:698395861632:android:1c7aa5c1213f0f7f",
         "android_client_info": {
-          "package_name": "com.mynewapp"
+          "package_name": "com.cleverpush.pushwoosh_sdk_test"
         }
       },
       "oauth_client": [
         {
-          "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
+          "client_id": "698395861632-1qhhu83msv2uf9i0mmm6fodu26ns11ms.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.cleverpush.pushwoosh_sdk_test",
+            "certificate_hash": "9160aadd9c2971ce85482790fa47f3ba10ddd059"
+          }
+        },
+        {
+          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDGvNCGExEWzsc55yNyL2MxYCxpdqUScww"
+          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
         }
       ],
       "services": {
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
+              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
               "client_type": 3
+            },
+            {
+              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.cleverpush.example"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:698395861632:android:caa14f139688a941d97c65",
+        "android_client_info": {
+          "package_name": "com.example.cleverpush_example"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.cleverpush.example"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:698395861632:android:5ad61a2c732b0e23d97c65",
+        "android_client_info": {
+          "package_name": "com.example.cleverpush_test"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.cleverpush.example"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:698395861632:android:afc24920395d5e33d97c65",
+        "android_client_info": {
+          "package_name": "de.express.app"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.cleverpush.example"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:698395861632:android:ce6b9c58eb1b43c6d97c65",
+        "android_client_info": {
+          "package_name": "io.ionic.starter"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.cleverpush.example"
+              }
             }
           ]
         }

--- a/cleverpush-example/google-services.json
+++ b/cleverpush-example/google-services.json
@@ -1,78 +1,34 @@
 {
   "project_info": {
-    "project_number": "698395861632",
-    "firebase_url": "https://cp-test-91df0.firebaseio.com",
-    "project_id": "cp-test-91df0",
-    "storage_bucket": "cp-test-91df0.appspot.com"
+    "project_number": "255590593470",
+    "project_id": "cp-test-33927",
+    "storage_bucket": "cp-test-33927.firebasestorage.app"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:698395861632:android:dfd1ac953d27fe34d97c65",
-        "android_client_info": {
-          "package_name": "com.capacitorjs.app.testapp"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.cleverpush.example"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:698395861632:android:1c5982891be00936d97c65",
+        "mobilesdk_app_id": "1:255590593470:android:9f7bcdcc3cf568ab5bffef",
         "android_client_info": {
           "package_name": "com.cleverpush.cleverpush_example_android"
         }
       },
       "oauth_client": [
         {
-          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+          "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
+          "current_key": "AIzaSyDGvNCGExEWzsc55yNyL2MxYCxpdqUScww"
         }
       ],
       "services": {
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+              "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
               "client_type": 3
-            },
-            {
-              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.cleverpush.example"
-              }
             }
           ]
         }
@@ -80,123 +36,36 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "1:698395861632:android:3b57669b41491a3d",
-        "android_client_info": {
-          "package_name": "com.cleverpush.cleverpushandroidtest"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "698395861632-6sld9g424e3lv976s67g7t9vqimt63dd.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.cleverpush.cleverpushandroidtest",
-            "certificate_hash": "9160aadd9c2971ce85482790fa47f3ba10ddd059"
-          }
-        },
-        {
-          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.cleverpush.example"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:698395861632:android:a1e66fd0cf4de302d97c65",
+        "mobilesdk_app_id": "1:255590593470:android:726d6e4582024ed85bffef",
         "android_client_info": {
           "package_name": "com.cleverpush.example"
         }
       },
       "oauth_client": [
         {
-          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.cleverpush.example"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:698395861632:android:1c7aa5c1213f0f7f",
-        "android_client_info": {
-          "package_name": "com.cleverpush.pushwoosh_sdk_test"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "698395861632-1qhhu83msv2uf9i0mmm6fodu26ns11ms.apps.googleusercontent.com",
+          "client_id": "255590593470-n58f4v5mlu1hovvc9vs157saaavmolp7.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "com.cleverpush.pushwoosh_sdk_test",
-            "certificate_hash": "9160aadd9c2971ce85482790fa47f3ba10ddd059"
+            "package_name": "com.cleverpush.example",
+            "certificate_hash": "d398826b29ee3556a90cb9e3caf04c8173ddad9b"
           }
         },
         {
-          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+          "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
+          "current_key": "AIzaSyDGvNCGExEWzsc55yNyL2MxYCxpdqUScww"
         }
       ],
       "services": {
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+              "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
               "client_type": 3
-            },
-            {
-              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.cleverpush.example"
-              }
             }
           ]
         }
@@ -204,143 +73,28 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "1:698395861632:android:caa14f139688a941d97c65",
+        "mobilesdk_app_id": "1:255590593470:android:28f928ca672e7d365bffef",
         "android_client_info": {
-          "package_name": "com.example.cleverpush_example"
+          "package_name": "com.mynewapp"
         }
       },
       "oauth_client": [
         {
-          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+          "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
+          "current_key": "AIzaSyDGvNCGExEWzsc55yNyL2MxYCxpdqUScww"
         }
       ],
       "services": {
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
+              "client_id": "255590593470-fe4cu2i8a4jpagijme228ghhgq35h1bp.apps.googleusercontent.com",
               "client_type": 3
-            },
-            {
-              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.cleverpush.example"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:698395861632:android:5ad61a2c732b0e23d97c65",
-        "android_client_info": {
-          "package_name": "com.example.cleverpush_test"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.cleverpush.example"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:698395861632:android:afc24920395d5e33d97c65",
-        "android_client_info": {
-          "package_name": "de.express.app"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.cleverpush.example"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:698395861632:android:ce6b9c58eb1b43c6d97c65",
-        "android_client_info": {
-          "package_name": "io.ionic.starter"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyDPLZgAWh4r2nyroUThZriV6tZPoVV-X4k"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "698395861632-0do2ajtra6em6c70913sm5rqsn7qed03.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "698395861632-50bv9k188l1kb4a7h8l6g8clultqvm39.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.cleverpush.example"
-              }
             }
           ]
         }

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
@@ -43,9 +43,20 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
     try {
       return getTokenWithClassFirebaseMessaging();
     } catch (Exception e) {
-      Logger.e(LOG_TAG, "FirebaseMessaging.getToken not found, attempting to use FirebaseInstanceId.getToken");
+      Logger.e(LOG_TAG, "FirebaseMessaging.getToken not found, attempting to use FirebaseInstanceId.getToken", e);
     }
-    return getTokenWithClassFirebaseInstanceId(senderId);
+
+    if (isFirebaseInstanceIdAvailable()) {
+      try {
+        return getTokenWithClassFirebaseInstanceId(senderId);
+      } catch (Throwable t) {
+        Logger.e(LOG_TAG, "FirebaseInstanceId fallback failed", t);
+      }
+    } else {
+      Logger.w(LOG_TAG, "FirebaseInstanceId not available on this Firebase version");
+    }
+
+    return null;
   }
 
   private void initFirebaseApp(String senderId) {
@@ -54,6 +65,15 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
     }
 
     firebaseApp = FirebaseApp.getInstance();
+  }
+
+  private boolean isFirebaseInstanceIdAvailable() {
+    try {
+      Class.forName("com.google.firebase.iid.FirebaseInstanceId");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
   }
 
   /**
@@ -91,24 +111,24 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
   @SuppressWarnings("unchecked")
   @WorkerThread
   private String getTokenWithClassFirebaseMessaging() throws Exception {
-    Exception exception;
     try {
-      Class<?> FirebaseInstanceIdClass = Class.forName("com.google.firebase.messaging.FirebaseMessaging");
-      Method getInstanceMethod = FirebaseInstanceIdClass.getMethod("getInstance");
-      Object instanceId = getInstanceMethod.invoke(null, null);
-      Method getTokenMethod = FirebaseInstanceIdClass.getMethod("getToken");
-      Task<String> tokenTask = (Task<String>) getTokenMethod.invoke(instanceId, null);
+      Class<?> firebaseMessagingClass = Class.forName("com.google.firebase.messaging.FirebaseMessaging");
+
+      // getInstance()
+      Method getInstanceMethod = firebaseMessagingClass.getMethod("getInstance");
+      Object instance = getInstanceMethod.invoke(null);
+
+      // getToken()
+      Method getTokenMethod = firebaseMessagingClass.getMethod("getToken");
+      Task<String> tokenTask = (Task<String>) getTokenMethod.invoke(instance);
+
       return Tasks.await(tokenTask);
-    } catch (ClassNotFoundException e) {
-      exception = e;
-    } catch (NoSuchMethodException e) {
-      exception = e;
-    } catch (IllegalAccessException e) {
-      exception = new IllegalAccessException();
-    } catch (InvocationTargetException e) {
-      exception = e;
+    } catch (ClassNotFoundException |
+             NoSuchMethodException |
+             IllegalAccessException |
+             InvocationTargetException e) {
+      throw e;
     }
-    throw exception;
   }
 
   private String getSenderIdFromConfig(JSONObject channelConfig) {


### PR DESCRIPTION
Fix FCM token retrieval for latest Firebase and add safe fallback handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Android FCM token retrieval on the latest Firebase by calling `FirebaseMessaging.getToken()` first and only falling back to `FirebaseInstanceId` if the class exists. Returns null when neither path is available to avoid crashes. Addresses Linear CP-11369.

- **Bug Fixes**
  - Invoke `FirebaseMessaging.getInstance().getToken()` via reflection and `Tasks.await(...)`.
  - Add `isFirebaseInstanceIdAvailable()` check; only use `FirebaseInstanceId.getToken(...)` when present; otherwise warn and return null.
  - Improve logging by including caught exceptions and explicit fallback failure messages.
  - Simplify reflection and rethrow specific exceptions in `getTokenWithClassFirebaseMessaging()`.

<sup>Written for commit b1f2d7c4b584b36e79e571c1c11bcaa3bf9cfb1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

