### PR TITLE
feature/cp-11407-add-translation-feature-to-app-push-android

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/ChannelTopic.java
+++ b/cleverpush/src/main/java/com/cleverpush/ChannelTopic.java
@@ -1,6 +1,11 @@
 package com.cleverpush;
 
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
+
+import org.json.JSONObject;
 
 public class ChannelTopic {
   private String id;
@@ -10,9 +15,11 @@ public class ChannelTopic {
   private String fcmBroadcastTopic;
   private String externalId;
   private Map<String, String> customData;
+  private Boolean nameTranslationEnabled;
+  private Map<String, String> nameTranslation;
 
   public ChannelTopic(String id, String name, String parentTopicId, Boolean defaultUnchecked, String fcmBroadcastTopic,
-                      String externalId, Map<String, String> customData) {
+                      String externalId, Map<String, String> customData, Boolean nameTranslationEnabled, Map<String, String> nameTranslation) {
     this.id = id;
     this.name = name;
     this.parentTopicId = parentTopicId;
@@ -20,6 +27,8 @@ public class ChannelTopic {
     this.fcmBroadcastTopic = fcmBroadcastTopic;
     this.externalId = externalId;
     this.customData = customData;
+    this.nameTranslationEnabled = nameTranslationEnabled;
+    this.nameTranslation = nameTranslation;
   }
 
   public String getId() {
@@ -52,5 +61,61 @@ public class ChannelTopic {
 
   public String toString() {
     return this.getId();
+  }
+
+  public Boolean getNameTranslationEnabled() {
+    return nameTranslationEnabled;
+  }
+
+  public Map<String, String> getNameTranslation() {
+    return nameTranslation;
+  }
+
+  /**
+   * Parses {@code nameTranslation} from channel topic JSON into a map, or returns null if absent or invalid.
+   */
+  public static Map<String, String> parseNameTranslation(JSONObject topicObject) {
+    if (topicObject == null || !topicObject.has("nameTranslation")) {
+      return null;
+    }
+    try {
+      JSONObject translationObj = topicObject.optJSONObject("nameTranslation");
+      if (translationObj == null) {
+        return null;
+      }
+      Map<String, String> nameTranslationMap = new HashMap<>();
+      Iterator<String> keys = translationObj.keys();
+      while (keys.hasNext()) {
+        String key = keys.next();
+        nameTranslationMap.put(key, translationObj.optString(key));
+      }
+      return nameTranslationMap;
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * Resolves the user-visible topic name: when {@code nameTranslationEnabled} is true, uses the device
+   * locale's language code to look up {@code nameTranslation}; otherwise or if no translation exists, uses {@code name}.
+   */
+  public static String resolveLocalizedDisplayName(JSONObject topicObject) {
+    if (topicObject == null) {
+      return "";
+    }
+    String name = topicObject.optString("name");
+    if (!topicObject.optBoolean("nameTranslationEnabled", false)) {
+      return name;
+    }
+    Map<String, String> translations = parseNameTranslation(topicObject);
+    if (translations == null || translations.isEmpty()) {
+      return name;
+    }
+    String language = Locale.getDefault().getLanguage();
+    String translated = translations.get(language);
+    if (translated != null && !translated.isEmpty()) {
+      return translated;
+    }
+    return name;
   }
 }

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -2224,14 +2224,18 @@ public class CleverPush {
                 Logger.e(LOG_TAG, "Error parsing customData for topic.", e);
               }
 
+              Map<String, String> nameTranslationMap = ChannelTopic.parseNameTranslation(topicObject);
+
               ChannelTopic topic = new ChannelTopic(
-                  topicObject.getString("_id"),
-                  topicObject.optString("name"),
-                  topicObject.optString("parentTopic", null),
-                  topicObject.optBoolean("defaultUnchecked", false),
-                  topicObject.optString("fcmBroadcastTopic", null),
-                  topicObject.optString("externalId", null),
-                  customData);
+                      topicObject.getString("_id"),
+                      topicObject.optString("name"),
+                      topicObject.optString("parentTopic", null),
+                      topicObject.optBoolean("defaultUnchecked", false),
+                      topicObject.optString("fcmBroadcastTopic", null),
+                      topicObject.optString("externalId", null),
+                      customData,
+                      topicObject.optBoolean("nameTranslationEnabled", false),
+                      nameTranslationMap);
               topics.add(topic);
             }
           }
@@ -3768,18 +3772,19 @@ public class CleverPush {
   private String getTopicCheckboxText(JSONObject topic) {
     int oneHour = 60 * 60;
     int topicLastChecked = getTopicLastChecked();
+    String displayName = ChannelTopic.resolveLocalizedDisplayName(topic);
     try {
       SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault());
       simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
       Date date = simpleDateFormat.parse(topic.optString("createdAt"));
       int topicCreatedAt = (int) (date.getTime() / 1000);
       if (this.isSubscribed() && topicsDialogShowWhenNewAdded && topicLastChecked > 0 && topicCreatedAt + oneHour > topicLastChecked) {
-        return topic.optString("name") + " ●";
+        return displayName + " ●";
       } else {
-        return topic.optString("name");
+        return displayName;
       }
     } catch (Exception e) {
-      return topic.optString("name");
+      return displayName;
     }
   }
 


### PR DESCRIPTION
Add support for topic name translations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds topic name translations for Android push topics. Implements locale-based display names with a safe fallback to the original name (CP-11407).

- **New Features**
  - Parse `nameTranslationEnabled` and `nameTranslation` from topic JSON in `CleverPush`.
  - Extend `ChannelTopic` with translation fields, getters, and helpers: `parseNameTranslation` and `resolveLocalizedDisplayName`.
  - Use the resolved localized name in the topic checkbox label (keeps the "●" indicator), falling back to `name` when missing or disabled.

<sup>Written for commit 493711c0cbbdc0785d1412c8ecb534beb2ccc609. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

