### PR TITLE
hotfix/cp-11502-firebase-messaging-library-outdated

### DIFF
--- a/cleverpush-example/build.gradle
+++ b/cleverpush-example/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.cleverpush.cleverpush_example_android"
-        minSdkVersion 21
+        minSdkVersion 25
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/cleverpush-example/build.gradle
+++ b/cleverpush-example/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.cleverpush.cleverpush_example_android"
-        minSdkVersion 25
+        minSdkVersion 23
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/cleverpush/build.gradle
+++ b/cleverpush/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     // Google & Firebase
     implementation 'com.google.android.gms:play-services-base:[10.2.1, 18.0.99]'
     implementation 'com.google.android.gms:play-services-location:[16.0.0, 21.0.99]'
-    api 'com.google.firebase:firebase-messaging:[10.2.1, 24.0.99]'
+    api 'com.google.firebase:firebase-messaging:[10.2.1, 25.0.99]'
 
     // Huawei
     compileOnly "com.huawei.hms:push:$huaweiHmsPushVersion"

--- a/cleverpush/build.gradle
+++ b/cleverpush/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     // Google & Firebase
     implementation 'com.google.android.gms:play-services-base:[10.2.1, 18.0.99]'
     implementation 'com.google.android.gms:play-services-location:[16.0.0, 21.0.99]'
-    api 'com.google.firebase:firebase-messaging:[10.2.1, 25.0.99]'
+    api 'com.google.firebase:firebase-messaging:[10.2.1, 26.0.0)'
 
     // Huawei
     compileOnly "com.huawei.hms:push:$huaweiHmsPushVersion"


### PR DESCRIPTION
Update Firebase Messaging dependency range to support v25.x versions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the supported range for `com.google.firebase:firebase-messaging` to include all v25.x releases, addressing Linear CP-11502. Also raises the example app `minSdkVersion` to 23.

- **Dependencies**
  - Set `com.google.firebase:firebase-messaging` to `[10.2.1, 26.0.0)` (was `[10.2.1, 24.0.99]`).

<sup>Written for commit 35ddb5deeae506165b4a85c986b6fb87d97873e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

