### PR TITLE
hotfix/cp-11566-push-delivery-issues-swp-twipe-report

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -3,6 +3,7 @@ package com.cleverpush;
 public class CleverPushPreferences {
 
   public static final String FCM_TOKEN = "CleverPush_FCM_TOKEN";
+  public static final String SYNCED_FCM_TOKEN = "CleverPush_SYNCED_FCM_TOKEN";
   public static final String HMS_TOKEN = "CleverPush_HMS_TOKEN";
   public static final String ADM_TOKEN = "CleverPush_ADM_TOKEN";
   public static final String CHANNEL_ID = "CleverPush_CHANNEL_ID";

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
@@ -169,7 +169,7 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
     String existingToken = sharedPreferences.getString(CleverPushPreferences.FCM_TOKEN, null);
 
     if (existingToken == null) {
-      return;
+      Logger.d(LOG_TAG, "No stored FCM token found. Syncing current token.");
     }
 
     new Thread(() -> {
@@ -180,16 +180,31 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
       }
       try {
         String newToken = changedToken != null ? changedToken : getTokenAttempt(senderId);
-        if (newToken != null && !newToken.equals(existingToken)) {
+        if (newToken == null) {
+          Logger.d(LOG_TAG, "checkChangedPushToken: no FCM token available yet, will retry on next sync.");
+          return;
+        }
+
+        boolean forcedTokenRefresh = changedToken != null;
+        boolean tokenMissingLocally = existingToken == null;
+        boolean tokenChanged = !newToken.equals(existingToken);
+
+        if (forcedTokenRefresh || tokenMissingLocally || tokenChanged) {
+          if (tokenMissingLocally) {
+            Logger.i(LOG_TAG, "Persisting FCM token after missing local copy (self-heal).");
+          }
           this.syncSubscription(newToken, new SubscribedCallbackListener() {
             @Override
             public void onSuccess(String subscriptionId) {
-              Logger.i(LOG_TAG, "Synchronized new FCM token: " + newToken);
+              Logger.i(LOG_TAG, "Synchronized FCM token: " + newToken);
+              sharedPreferences.edit()
+                      .putString(CleverPushPreferences.FCM_TOKEN, newToken)
+                      .apply();
             }
 
             @Override
             public void onFailure(Throwable exception) {
-
+              Logger.e(LOG_TAG, "Failed to sync FCM token", exception);
             }
           }, senderId);
         } else {

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
@@ -178,8 +178,10 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
         Logger.e(LOG_TAG, "SubscriptionManager: Getting FCM Sender ID failed");
         return;
       }
+
       try {
         String newToken = changedToken != null ? changedToken : getTokenAttempt(senderId);
+
         if (newToken == null) {
           Logger.d(LOG_TAG, "checkChangedPushToken: no FCM token available yet, will retry on next sync.");
           return;

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
@@ -166,14 +166,19 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
   @Override
   public void checkChangedPushToken(JSONObject channelConfig, String changedToken) {
     SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(this.context);
-    String existingToken = sharedPreferences.getString(CleverPushPreferences.FCM_TOKEN, null);
+
+    // IMPORTANT:
+    // Compare against LAST SUCCESSFULLY SYNCED token,
+    // not the latest locally cached Firebase token.
+    String existingToken = sharedPreferences.getString(CleverPushPreferences.SYNCED_FCM_TOKEN, null);
 
     if (existingToken == null) {
-      Logger.d(LOG_TAG, "No stored FCM token found. Syncing current token.");
+      Logger.d(LOG_TAG, "No synced FCM token found. Syncing current token.");
     }
 
     new Thread(() -> {
       String senderId = this.getSenderIdFromConfig(channelConfig);
+
       if (senderId == null) {
         Logger.e(LOG_TAG, "SubscriptionManager: Getting FCM Sender ID failed");
         return;
@@ -192,23 +197,31 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
         boolean tokenChanged = !newToken.equals(existingToken);
 
         if (forcedTokenRefresh || tokenMissingLocally || tokenChanged) {
-          if (tokenMissingLocally) {
-            Logger.i(LOG_TAG, "Persisting FCM token after missing local copy (self-heal).");
-          }
-          this.syncSubscription(newToken, new SubscribedCallbackListener() {
-            @Override
-            public void onSuccess(String subscriptionId) {
-              Logger.i(LOG_TAG, "Synchronized FCM token: " + newToken);
-              sharedPreferences.edit()
-                      .putString(CleverPushPreferences.FCM_TOKEN, newToken)
-                      .apply();
-            }
 
-            @Override
-            public void onFailure(Throwable exception) {
-              Logger.e(LOG_TAG, "Failed to sync FCM token", exception);
-            }
-          }, senderId);
+          this.syncSubscription(
+                  newToken,
+                  new SubscribedCallbackListener() {
+
+                    @Override
+                    public void onSuccess(String subscriptionId) {
+                      Logger.i(LOG_TAG, "Synchronized FCM token: " + newToken);
+
+                      sharedPreferences.edit()
+                              // latest local token
+                              .putString(CleverPushPreferences.FCM_TOKEN, newToken)
+                              // last successfully synced token
+                              .putString(CleverPushPreferences.SYNCED_FCM_TOKEN, newToken)
+                              .apply();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable exception) {
+                      Logger.e(LOG_TAG, "Failed to sync FCM token", exception);
+                    }
+                  },
+                  senderId
+          );
+
         } else {
           Logger.d(LOG_TAG, "FCM token has not changed: " + newToken);
         }

--- a/cleverpush/src/main/java/com/cleverpush/service/CleverPushFcmListenerService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/CleverPushFcmListenerService.java
@@ -56,10 +56,15 @@ public class CleverPushFcmListenerService extends FirebaseMessagingService {
     Logger.d(LOG_TAG, "FCM: onNewToken");
 
     SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(this);
+
+    // Always persist the latest FCM token locally so we never lose a rotation,
+    // even if it arrives before the first subscribe() completes.
+    sharedPreferences.edit().putString(CleverPushPreferences.FCM_TOKEN, token).apply();
+
     String subscriptionId = sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ID, null);
 
     if (subscriptionId == null) {
-      Logger.d(LOG_TAG, "CleverPushFcmListenerService onNewToken: There is no subscription for CleverPush SDK.");
+      Logger.d(LOG_TAG, "CleverPushFcmListenerService onNewToken: no subscription yet, token cached for next subscribe.");
       return;
     }
 

--- a/cleverpush/src/main/java/com/cleverpush/service/CleverPushFcmListenerService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/CleverPushFcmListenerService.java
@@ -56,27 +56,24 @@ public class CleverPushFcmListenerService extends FirebaseMessagingService {
     Logger.d(LOG_TAG, "FCM: onNewToken");
 
     SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(this);
+
+    // Always store latest local token immediately.
+    // This ensures we never lose token rotations.
+    sharedPreferences.edit().putString(CleverPushPreferences.FCM_TOKEN, token).apply();
+
     String subscriptionId = sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ID, null);
 
     if (subscriptionId == null) {
-      // No subscription yet: the next subscribe() will fetch the current token
-      // straight from FCM, so nothing is lost by skipping local persistence
-      // here. We intentionally do NOT write FCM_TOKEN now — that key must
-      // reflect the last value successfully synced to the server, which is
-      // what checkChangedPushToken() relies on to detect rotations.
-      Logger.d(LOG_TAG, "CleverPushFcmListenerService onNewToken: no subscription yet, will be picked up on next subscribe.");
+      Logger.d(LOG_TAG, "CleverPushFcmListenerService onNewToken: no subscription yet, token cached for next subscribe.");
       return;
     }
 
-    // Persistence of FCM_TOKEN is deliberately gated on a successful server
-    // sync inside SubscriptionManagerFCM.checkChangedPushToken(...).
-    // If this sync attempt is dropped (e.g. getChannelConfig's callback never
-    // fires because CleverPush isn't initialized in this process, or the HTTP
-    // call fails), the stored token still reflects the last server-known
-    // value. On the next app start, checkChangedPushToken(config, null) will
-    // observe that the live FCM token differs from the stored one and re-sync.
     CleverPush cleverPush = CleverPush.getInstance(this);
+
     cleverPush.getChannelConfig(
-        (JSONObject channelConfig) -> cleverPush.getSubscriptionManager().checkChangedPushToken(channelConfig, token));
+            (JSONObject channelConfig) ->
+                    cleverPush.getSubscriptionManager()
+                            .checkChangedPushToken(channelConfig, token)
+    );
   }
 }

--- a/cleverpush/src/main/java/com/cleverpush/service/CleverPushFcmListenerService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/CleverPushFcmListenerService.java
@@ -56,18 +56,25 @@ public class CleverPushFcmListenerService extends FirebaseMessagingService {
     Logger.d(LOG_TAG, "FCM: onNewToken");
 
     SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(this);
-
-    // Always persist the latest FCM token locally so we never lose a rotation,
-    // even if it arrives before the first subscribe() completes.
-    sharedPreferences.edit().putString(CleverPushPreferences.FCM_TOKEN, token).apply();
-
     String subscriptionId = sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ID, null);
 
     if (subscriptionId == null) {
-      Logger.d(LOG_TAG, "CleverPushFcmListenerService onNewToken: no subscription yet, token cached for next subscribe.");
+      // No subscription yet: the next subscribe() will fetch the current token
+      // straight from FCM, so nothing is lost by skipping local persistence
+      // here. We intentionally do NOT write FCM_TOKEN now — that key must
+      // reflect the last value successfully synced to the server, which is
+      // what checkChangedPushToken() relies on to detect rotations.
+      Logger.d(LOG_TAG, "CleverPushFcmListenerService onNewToken: no subscription yet, will be picked up on next subscribe.");
       return;
     }
 
+    // Persistence of FCM_TOKEN is deliberately gated on a successful server
+    // sync inside SubscriptionManagerFCM.checkChangedPushToken(...).
+    // If this sync attempt is dropped (e.g. getChannelConfig's callback never
+    // fires because CleverPush isn't initialized in this process, or the HTTP
+    // call fails), the stored token still reflects the last server-known
+    // value. On the next app start, checkChangedPushToken(config, null) will
+    // observe that the live FCM token differs from the stored one and re-sync.
     CleverPush cleverPush = CleverPush.getInstance(this);
     cleverPush.getChannelConfig(
         (JSONObject channelConfig) -> cleverPush.getSubscriptionManager().checkChangedPushToken(channelConfig, token));


### PR DESCRIPTION
Improve FCM token sync reliability and stale token recovery

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FCM token persistence and sync conditions, which can affect subscription state and push delivery if the new comparison/persistence logic misbehaves. Risk is mitigated by keeping the old local token key and only adding a new synced-token marker.
> 
> **Overview**
> Improves FCM token rotation/stale-token recovery by separating the **latest locally seen** token from the **last successfully synced** token.
> 
> `SubscriptionManagerFCM.checkChangedPushToken` now compares against `SYNCED_FCM_TOKEN` and triggers a resync when the token is forced, missing, or changed, updating both `FCM_TOKEN` and `SYNCED_FCM_TOKEN` only after a successful server sync (with clearer logging and failure reporting). `CleverPushFcmListenerService.onNewToken` now immediately caches the new token locally and, when a subscription exists, routes the update through `getChannelConfig` → `checkChangedPushToken` to ensure the server is brought in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64829a49f5203cd7c453baf8ae17f67959d345d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates the local cached FCM token from the last successfully synced token to improve rotation handling and automatic recovery. Reduces push delivery failures reported in CP-11566 (SWP/Twipe).

- **Bug Fixes**
  - In `SubscriptionManagerFCM.checkChangedPushToken`, compare against `SYNCED_FCM_TOKEN` (new) instead of local `FCM_TOKEN`; sync when forced/missing/changed; skip only if no token yet; on success update `FCM_TOKEN` and `SYNCED_FCM_TOKEN`; clearer logs and errors.
  - In `CleverPushFcmListenerService.onNewToken`, cache the latest token in `FCM_TOKEN` immediately (even without a subscription), then load config and call `checkChangedPushToken` for server sync.

<sup>Written for commit 64829a49f5203cd7c453baf8ae17f67959d345d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

