### PR TITLE
feature/cp-11598-android-implement-regenerating-the-push-token-by-system

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -16,6 +16,7 @@ public class CleverPushPreferences {
   public static final String SUBSCRIPTION_LANGUAGE = "CleverPush_SUBSCRIPTION_LANGUAGE";
   public static final String SUBSCRIPTION_COUNTRY = "CleverPush_SUBSCRIPTION_COUNTRY";
   public static final String SUBSCRIPTION_CREATED_AT = "CleverPush_SUBSCRIPTION_CREATED_AT";
+  public static final String REGENERATE_PUSH_TOKEN_REQUESTED_AT = "CleverPush_REGENERATE_PUSH_TOKEN_REQUESTED_AT";
   public static final String NOTIFICATIONS = "CleverPush_NOTIFICATIONS"; // deprecated, now using NOTIFICATIONS_JSON
   public static final String NOTIFICATIONS_JSON = "CleverPush_NOTIFICATIONS_JSON";
   public static final String LAST_NOTIFICATION_ID = "CleverPush_LAST_NOTIFICATION_ID";

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManager.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManager.java
@@ -12,8 +12,6 @@ public interface SubscriptionManager {
     ADM,
   }
 
-  ;
-
   void subscribe(JSONObject channelConfig, SubscribedCallbackListener callback);
 
   void checkChangedPushToken(JSONObject channelConfig);

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerADM.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerADM.java
@@ -18,6 +18,7 @@ public class SubscriptionManagerADM extends SubscriptionManagerBase {
 
   @Override
   public void subscribe(JSONObject channelConfig, final SubscribedCallbackListener subscribedListener) {
+    this.lastChannelConfig = channelConfig;
     Context context = this.context;
     new Thread(() -> {
       final ADM adm = new ADM(context);
@@ -33,6 +34,6 @@ public class SubscriptionManagerADM extends SubscriptionManagerBase {
 
   @Override
   public void checkChangedPushToken(JSONObject channelConfig, String changedToken) {
-
+    this.lastChannelConfig = channelConfig;
   }
 }

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
@@ -26,12 +26,23 @@ import java.util.Set;
 import java.util.TimeZone;
 
 abstract class SubscriptionManagerBase implements SubscriptionManager {
+  protected volatile JSONObject lastChannelConfig;
   Context context;
   SubscriptionManagerType type;
 
   SubscriptionManagerBase(Context context, SubscriptionManagerType type) {
     this.context = context;
     this.type = type;
+  }
+
+  /**
+   * Hook for platform-specific push-token regeneration. Default is a no-op;
+   * platforms that support deleting/refreshing their push token (e.g. FCM)
+   * should override this and use {@link #lastChannelConfig} to obtain any
+   * platform-specific config (sender id, app id, ...).
+   */
+  protected void regeneratePushToken() {
+    // no-op by default
   }
 
   void syncSubscription(String token, SubscribedCallbackListener subscribedListener) {
@@ -144,14 +155,16 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
             long subscriptionCreatedAt = sharedPreferences.getLong(CleverPushPreferences.SUBSCRIPTION_CREATED_AT, 0);
             if (subscriptionCreatedAt == 0 || isSubscriptionChanged) {
               sharedPreferences.edit()
-                  .putLong(CleverPushPreferences.SUBSCRIPTION_CREATED_AT, (int) (System.currentTimeMillis() / 1000L))
-                  .apply();
+                      .putLong(CleverPushPreferences.SUBSCRIPTION_CREATED_AT, (int) (System.currentTimeMillis() / 1000L))
+                      .apply();
             }
             sharedPreferences.edit().putString(CleverPushPreferences.SUBSCRIPTION_ID, newSubscriptionId).apply();
             sharedPreferences.edit()
-                .putInt(CleverPushPreferences.SUBSCRIPTION_LAST_SYNC, (int) (System.currentTimeMillis() / 1000L))
-                .apply();
+                    .putInt(CleverPushPreferences.SUBSCRIPTION_LAST_SYNC, (int) (System.currentTimeMillis() / 1000L))
+                    .apply();
           }
+
+          handleRegeneratePushTokenRequestedAt(sharedPreferences, responseJson);
           if (responseJson.has("topics")) {
             JSONArray topicsArray = responseJson.getJSONArray("topics");
             List<String> topicIds = new ArrayList<>();
@@ -165,7 +178,7 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
             }
             if (!CleverPush.isSubscribeForTopicsDialog()) {
               sharedPreferences.edit().putStringSet(CleverPushPreferences.SUBSCRIPTION_TOPICS, new HashSet<>(topicIds))
-                  .apply();
+                      .apply();
             } else {
               CleverPush.setIsSubscribeForTopicsDialog(false);
             }
@@ -174,7 +187,7 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
               int topicsVersion = responseJson.getInt("topicsVersion");
               if (topicsVersion > 0) {
                 sharedPreferences.edit().putInt(CleverPushPreferences.SUBSCRIPTION_TOPICS_VERSION, topicsVersion)
-                    .apply();
+                        .apply();
               }
             }
           }
@@ -196,7 +209,9 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
           }
 
           if (newSubscriptionId != null) {
-            subscribedListener.onSuccess(newSubscriptionId);
+            if (subscribedListener != null) {
+              subscribedListener.onSuccess(newSubscriptionId);
+            }
           }
         } catch (Throwable throwable) {
           Logger.e(LOG_TAG, "Error in syncSubscription request's onSuccess.", throwable);
@@ -210,7 +225,9 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
           syncSubscription(token, subscribedListener, senderId, true);
           return;
         }
-        subscribedListener.onFailure(throwable);
+        if (subscribedListener != null) {
+          subscribedListener.onFailure(throwable);
+        }
         if (throwable != null) {
           Logger.e(LOG_TAG, "Failed while sync subscription request." +
                   "\nStatus code: " + statusCode +
@@ -234,6 +251,54 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
   @Override
   public void checkChangedPushToken(JSONObject channelConfig) {
     this.checkChangedPushToken(channelConfig, null);
+  }
+
+  /**
+   * Handles the {@code regeneratePushTokenRequestedAt} value returned by
+   * {@code /subscription/sync/}. If the server value differs from the
+   * locally stored value, the new value is persisted and
+   * {@link #regeneratePushToken()} is triggered.
+   *
+   * If the field is missing, invalid, or unchanged, no action is taken.
+   */
+  private void handleRegeneratePushTokenRequestedAt(SharedPreferences sharedPreferences, JSONObject responseJson) {
+    try {
+      if (!responseJson.has("regeneratePushTokenRequestedAt")) {
+        return;
+      }
+
+      String serverRequestedAt = responseJson.optString("regeneratePushTokenRequestedAt", null);
+
+      if (serverRequestedAt == null
+              || serverRequestedAt.isEmpty()
+              || "null".equalsIgnoreCase(serverRequestedAt)) {
+        return;
+      }
+
+      String localRequestedAt = sharedPreferences.getString(
+              CleverPushPreferences.REGENERATE_PUSH_TOKEN_REQUESTED_AT,
+              null
+      );
+
+      if (serverRequestedAt.equals(localRequestedAt)) {
+        return;
+      }
+
+      sharedPreferences.edit()
+              .putString(
+                      CleverPushPreferences.REGENERATE_PUSH_TOKEN_REQUESTED_AT,
+                      serverRequestedAt
+              )
+              .apply();
+
+      Logger.d(LOG_TAG, "regeneratePushTokenRequestedAt changed (local=" + localRequestedAt
+              + ", server=" + serverRequestedAt + "), regenerating push token.");
+
+      regeneratePushToken();
+
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "Error in handleRegeneratePushTokenRequestedAt", e);
+    }
   }
 
 }

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
@@ -29,6 +29,8 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
   private static final String TOKEN_BLACKLISTED = "BLACKLISTED";
   private static final String ERROR_SERVICE_NOT_AVAILABLE = "SERVICE_NOT_AVAILABLE";
   private static final String THREAD_NAME = "FCM_GET_TOKEN";
+  private static final String REGEN_THREAD_NAME = "FCM_REGEN_TOKEN";
+  private volatile boolean isRegeneratingPushToken = false;
 
   private FirebaseApp firebaseApp;
   private Thread registerThread;
@@ -146,6 +148,7 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
 
   @Override
   public void subscribe(JSONObject channelConfig, SubscribedCallbackListener subscribedListener) {
+    this.lastChannelConfig = channelConfig;
     String senderId = this.getSenderIdFromConfig(channelConfig);
     if (senderId == null) {
       Logger.e(LOG_TAG, "SubscriptionManager: Getting FCM Sender ID failed");
@@ -165,6 +168,7 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
 
   @Override
   public void checkChangedPushToken(JSONObject channelConfig, String changedToken) {
+    this.lastChannelConfig = channelConfig;
     SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(this.context);
 
     // IMPORTANT:
@@ -185,6 +189,11 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
       }
 
       try {
+        if (isRegeneratingPushToken) {
+          Logger.d(LOG_TAG, "Ignoring checkChangedPushToken because token regeneration is already in progress.");
+          return;
+        }
+
         String newToken = changedToken != null ? changedToken : getTokenAttempt(senderId);
 
         if (newToken == null) {
@@ -283,6 +292,94 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
       }
 
       return null;
+    }
+  }
+
+  /**
+   * Regenerates the FCM push token by deleting the existing token,
+   * requesting a new one from Firebase, and synchronizing it with
+   * the CleverPush backend.
+   */
+  @Override
+  protected void regeneratePushToken() {
+    final JSONObject channelConfig = this.lastChannelConfig;
+    final String senderId = this.getSenderIdFromConfig(channelConfig);
+    if (senderId == null) {
+      Logger.e(LOG_TAG, "regeneratePushToken: FCM Sender ID is not available, skipping regeneration.");
+      return;
+    }
+
+    isRegeneratingPushToken = true;
+
+    new Thread(() -> {
+      try {
+        initFirebaseApp(senderId);
+
+        // 1. Delete the current FCM token so the next getToken() returns a new one.
+        try {
+          deleteTokenWithClassFirebaseMessaging();
+          Logger.d(LOG_TAG, "regeneratePushToken: deleted existing FCM token.");
+        } catch (Throwable t) {
+          Logger.e(LOG_TAG, "regeneratePushToken: failed to delete existing FCM token, attempting to fetch new token anyway.", t);
+        }
+
+        // 2. Clear locally cached tokens so checkChangedPushToken-like flows
+        //    do not short-circuit and so the next sync actually pushes the new token.
+        SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(this.context);
+        sharedPreferences.edit()
+            .remove(CleverPushPreferences.FCM_TOKEN)
+            .remove(CleverPushPreferences.SYNCED_FCM_TOKEN)
+            .apply();
+
+        // 3. Fetch a fresh token from Firebase.
+        String newToken = getTokenAttempt(senderId);
+        if (newToken == null) {
+          Logger.d(LOG_TAG, "regeneratePushToken: no FCM token available yet after regeneration, will retry on next sync.");
+          return;
+        }
+
+        Logger.i(LOG_TAG, "regeneratePushToken: obtained new FCM token: " + newToken);
+
+        // 4. Sync the new token with the CleverPush backend.
+        this.syncSubscription(newToken, new SubscribedCallbackListener() {
+          @Override
+          public void onSuccess(String subscriptionId) {
+            Logger.i(LOG_TAG, "regeneratePushToken: synchronized regenerated FCM token.");
+            sharedPreferences.edit()
+                .putString(CleverPushPreferences.FCM_TOKEN, newToken)
+                .putString(CleverPushPreferences.SYNCED_FCM_TOKEN, newToken)
+                .apply();
+            isRegeneratingPushToken = false;
+          }
+
+          @Override
+          public void onFailure(Throwable exception) {
+            Logger.e(LOG_TAG, "regeneratePushToken: failed to sync regenerated FCM token.", exception);
+            isRegeneratingPushToken = false;
+          }
+        }, senderId);
+      } catch (Throwable throwable) {
+        Logger.e(LOG_TAG, "Unknown error in regeneratePushToken.", throwable);
+        isRegeneratingPushToken = false;
+      }
+    }, REGEN_THREAD_NAME).start();
+  }
+
+  /**
+   * Reflective call to {@code FirebaseMessaging.getInstance().deleteToken()} so the
+   * SDK keeps working even when only the Firebase classes are present at runtime.
+   */
+  @WorkerThread
+  @SuppressWarnings("unchecked")
+  private void deleteTokenWithClassFirebaseMessaging() throws Exception {
+    Class<?> firebaseMessagingClass = Class.forName("com.google.firebase.messaging.FirebaseMessaging");
+    Method getInstanceMethod = firebaseMessagingClass.getMethod("getInstance");
+    Object instance = getInstanceMethod.invoke(null);
+
+    Method deleteTokenMethod = firebaseMessagingClass.getMethod("deleteToken");
+    Task<Void> deleteTask = (Task<Void>) deleteTokenMethod.invoke(instance);
+    if (deleteTask != null) {
+      Tasks.await(deleteTask);
     }
   }
 

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
@@ -335,6 +335,7 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
         String newToken = getTokenAttempt(senderId);
         if (newToken == null) {
           Logger.d(LOG_TAG, "regeneratePushToken: no FCM token available yet after regeneration, will retry on next sync.");
+          isRegeneratingPushToken = false;
           return;
         }
 

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerHMS.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerHMS.java
@@ -34,6 +34,7 @@ public class SubscriptionManagerHMS extends SubscriptionManagerBase {
 
   @Override
   public void subscribe(JSONObject channelConfig, SubscribedCallbackListener subscribedListener) {
+    this.lastChannelConfig = channelConfig;
     this.subscribedListener = subscribedListener;
 
     new Thread(() -> {
@@ -67,6 +68,7 @@ public class SubscriptionManagerHMS extends SubscriptionManagerBase {
 
   @Override
   public void checkChangedPushToken(JSONObject channelConfig, String changedToken) {
+    this.lastChannelConfig = channelConfig;
     SharedPreferencesManager prefManager = new SharedPreferencesManager(this.context);
     String existingToken = prefManager.getString(CleverPushPreferences.HMS_TOKEN, null);
 


### PR DESCRIPTION
Add support for FCM push token regeneration by detecting regeneratePushTokenRequestedAt changes, deleting existing tokens, clearing cached tokens, fetching a new Firebase token, and syncing it with the backend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription sync flow to trigger FCM token deletion/regeneration and resync based on a server-provided flag, which could impact push delivery if mis-triggered or if Firebase reflection calls fail.
> 
> **Overview**
> Adds **server-driven push-token regeneration** on Android by persisting `regeneratePushTokenRequestedAt` from `/subscription/sync` and triggering a regeneration when the value changes.
> 
> Introduces a `regeneratePushToken()` hook in `SubscriptionManagerBase` (with `lastChannelConfig` captured across managers), and implements the FCM version to delete the current Firebase token (via reflection), clear cached tokens, fetch a fresh token, and resync it while preventing concurrent regeneration and making subscription callbacks null-safe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804b0e618940894584a300d6863a3eb1849ab902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements system-driven FCM push token regeneration on Android. When the backend updates regeneratePushTokenRequestedAt, the SDK deletes the old token, fetches a new one, and syncs it. Aligns with Linear CP-11598.

- New Features
  - Reads regeneratePushTokenRequestedAt from `/subscription/sync`, stores it in prefs, and triggers regeneration on change.
  - FCM: deletes the existing token via `FirebaseMessaging.deleteToken()`, clears cached tokens, fetches a new token, then syncs and stores it.
  - Prevents concurrent regeneration, ignores token checks while regeneration is in progress, and resets the flag if Firebase returns null.

- Refactors
  - Adds lastChannelConfig to the base manager and sets it in FCM/HMS/ADM flows for reuse.
  - Makes subscribed callbacks null-safe and applies minor formatting fixes.

<sup>Written for commit 804b0e618940894584a300d6863a3eb1849ab902. Summary will update on new commits. <a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/350?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

