### PR TITLE
feature/cp-11581-db-support-for-enhanced-topic-selection-popup-configurable

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -22,8 +22,11 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.service.notification.StatusBarNotification;
+import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup;
 import android.webkit.WebView;
+import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
@@ -204,6 +207,7 @@ public class CleverPush {
   private boolean showingTopicsDialog = false;
   private boolean confirmAlertShown = false;
   private boolean topicsDialogShowWhenNewAdded = false;
+  private Runnable topicBulkActionsUpdater;
   private InitializeListener initializeListener;
 
   private AddSubscriptionTags addSubscriptionTagsHelper;
@@ -3464,6 +3468,7 @@ public class CleverPush {
           Set<String> selectedTopics = new HashSet<>(instance.getSubscriptionTopics());
           final boolean hasDeSelectAllInitial = this.hasDeSelectAll();
           boolean showUnsubscribeCheckbox = channelConfig.optBoolean("topicsDialogShowUnsubscribe", false);
+          boolean topicsDialogBulkActions = channelConfig.optBoolean("topicsDialogBulkActions", false);
 
           LinearLayout checkboxLayout = getTopicCheckboxLayout();
           LinearLayout parentLayout = getTopicParentLayout();
@@ -3483,6 +3488,11 @@ public class CleverPush {
 
           setTopicCheckboxList(parentLayout, channelTopics, unsubscribeCheckbox, hasDeSelectAll(), getNightModeFlags(),
                   selectedTopics);
+
+          if (topicsDialogBulkActions) {
+            View bulkActionsView = getTopicBulkActionsLayout(parentLayout, unsubscribeCheckbox, getNightModeFlags());
+            checkboxLayout.addView(bulkActionsView);
+          }
 
           checkboxLayout.addView(scrollView);
 
@@ -3538,12 +3548,26 @@ public class CleverPush {
       headerTitle = CleverPush.context.getResources().getString(R.string.topics_dialog_title);
     }
 
+    String saveText = null;
+    if (channelConfig.has("confirmAlertSelectTopicsSaveText")) {
+      try {
+        saveText = channelConfig.getString("confirmAlertSelectTopicsSaveText");
+      } catch (Exception e) {
+        Logger.e(LOG_TAG, "Error while getting save button text from channel config.", e);
+      }
+    }
+
+    if (saveText == null || saveText.isEmpty()) {
+      saveText = CleverPush.context.getResources().getString(R.string.save);
+    }
+
     alertBuilder.setTitle(headerTitle);
     alertBuilder.setView(checkboxLayout);
 
     alertBuilder.setOnDismissListener(dialogInterface -> {
       updateTopicLastCheckedTime();
       showingTopicsDialog = false;
+      topicBulkActionsUpdater = null;
     });
 
     alertBuilder.setNegativeButton(CleverPush.context.getResources().getString(R.string.cancel),
@@ -3559,7 +3583,7 @@ public class CleverPush {
           showingTopicsDialog = false;
         });
 
-    alertBuilder.setPositiveButton(CleverPush.context.getResources().getString(R.string.save), (dialogInterface, i) -> {
+    alertBuilder.setPositiveButton(saveText, (dialogInterface, i) -> {
       if (unsubscribeCheckbox != null && unsubscribeCheckbox.isChecked()) {
         unsubscribe();
         setDeSelectAll(true);
@@ -3627,6 +3651,127 @@ public class CleverPush {
   }
 
   /**
+   * Builds a horizontal "Select All" / "Remove All" header that is displayed above the topic
+   * checkbox list when the channel configuration has {@code topicsDialogBulkActions} enabled.
+   * Both buttons are disabled (greyed out) when their action would be a no-op (all checked /
+   * none checked).
+   */
+  private View getTopicBulkActionsLayout(LinearLayout parentLayout, CheckBox unsubscribeCheckbox,
+                                         int nightModeFlags) {
+    LinearLayout bulkActionsLayout = new LinearLayout(context);
+    LinearLayout.LayoutParams bulkActionsLayoutParams = new LinearLayout.LayoutParams(
+        LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+    bulkActionsLayoutParams.setMargins(45, 30, 45, 0);
+    bulkActionsLayout.setLayoutParams(bulkActionsLayoutParams);
+    bulkActionsLayout.setOrientation(LinearLayout.HORIZONTAL);
+
+    Button selectAllButton = getTopicBulkActionButton(R.string.select_all, Gravity.START, nightModeFlags);
+    selectAllButton.setOnClickListener(v ->
+        setAllTopicCheckboxesChecked(parentLayout, unsubscribeCheckbox, true));
+
+    Button removeAllButton = getTopicBulkActionButton(R.string.remove_all, Gravity.END, nightModeFlags);
+    removeAllButton.setOnClickListener(v ->
+        setAllTopicCheckboxesChecked(parentLayout, unsubscribeCheckbox, false));
+
+    bulkActionsLayout.addView(selectAllButton);
+    bulkActionsLayout.addView(removeAllButton);
+
+    topicBulkActionsUpdater = () -> {
+      int[] counts = countTopicCheckboxes(parentLayout, unsubscribeCheckbox);
+      int total = counts[0];
+      int checked = counts[1];
+      selectAllButton.setEnabled(total > 0 && checked < total);
+      removeAllButton.setEnabled(checked > 0);
+    };
+    topicBulkActionsUpdater.run();
+
+    return bulkActionsLayout;
+  }
+
+  /**
+   * Creates a borderless {@link Button} used as a bulk action entry inside the topics dialog.
+   * The text color follows the same night-mode adaption as {@link #getTopicCheckbox}, and uses
+   * a {@link ColorStateList} so the disabled state is automatically rendered with a dimmer
+   * color when the button is disabled via {@link Button#setEnabled(boolean)}.
+   */
+  private Button getTopicBulkActionButton(int textResId, int gravity, int nightModeFlags) {
+    Button button = new Button(context);
+    LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+        0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
+    button.setLayoutParams(params);
+    button.setText(textResId);
+    button.setAllCaps(false);
+    button.setBackground(null);
+    button.setPadding(0, 16, 0, 16);
+    button.setGravity(gravity | Gravity.CENTER_VERTICAL);
+
+    int enabledColor;
+    int disabledColor;
+    if (!this.disableNightModeAdaption && nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
+      enabledColor = Color.WHITE;
+      disabledColor = Color.argb(102, 255, 255, 255);
+    } else {
+      enabledColor = button.getCurrentTextColor();
+      disabledColor = Color.argb(102, 0, 0, 0);
+    }
+    ColorStateList textColors = new ColorStateList(
+        new int[][] {
+            new int[] {-android.R.attr.state_enabled},
+            new int[0]
+        },
+        new int[] {disabledColor, enabledColor}
+    );
+    button.setTextColor(textColors);
+    return button;
+  }
+
+  /**
+   * Recursively toggles every topic checkbox under {@code parentLayout} to the given state.
+   * The unsubscribe checkbox (if present) is skipped so that its state is only updated by the
+   * existing {@link #toggleCheckedTopic} side effects.
+   */
+  private void setAllTopicCheckboxesChecked(ViewGroup parentLayout, CheckBox unsubscribeCheckbox,
+                                            boolean checked) {
+    for (int i = 0; i < parentLayout.getChildCount(); i++) {
+      View child = parentLayout.getChildAt(i);
+      if (child instanceof CheckBox) {
+        if (child == unsubscribeCheckbox) {
+          continue;
+        }
+        ((CheckBox) child).setChecked(checked);
+      } else if (child instanceof ViewGroup) {
+        setAllTopicCheckboxesChecked((ViewGroup) child, unsubscribeCheckbox, checked);
+      }
+    }
+  }
+
+  /**
+   * Counts the total number of topic checkboxes (excluding {@code unsubscribeCheckbox}) and how
+   * many of them are currently checked. Returns {@code [total, checked]}.
+   */
+  private int[] countTopicCheckboxes(ViewGroup parentLayout, CheckBox unsubscribeCheckbox) {
+    int total = 0;
+    int checked = 0;
+    for (int i = 0; i < parentLayout.getChildCount(); i++) {
+      View child = parentLayout.getChildAt(i);
+      if (child instanceof CheckBox) {
+        if (child == unsubscribeCheckbox) {
+          continue;
+        }
+        total++;
+        if (((CheckBox) child).isChecked()) {
+          checked++;
+        }
+      } else if (child instanceof ViewGroup) {
+        int[] sub = countTopicCheckboxes((ViewGroup) child, unsubscribeCheckbox);
+        total += sub[0];
+        checked += sub[1];
+      }
+    }
+    return new int[] {total, checked};
+  }
+
+  /**
    * Will create list of checkbox for the topics.
    *
    * @param parentLayout   parent layout to add checkboxes
@@ -3651,6 +3796,10 @@ public class CleverPush {
 
     setupTopicParentCheckboxes(parentLayout, unsubscribeCheckbox, channelTopics, deselectAll, nightModeFlags,
         selectedTopics);
+
+    if (topicBulkActionsUpdater != null) {
+      topicBulkActionsUpdater.run();
+    }
   }
 
   private boolean isTopicCheckboxChecked(Set<String> selectedTopics, JSONObject topic) {
@@ -3711,6 +3860,9 @@ public class CleverPush {
     }
     if (selectedTopics.size() == 0 && unsubscribeCheckbox != null) {
       unsubscribeCheckbox.setChecked(true);
+    }
+    if (topicBulkActionsUpdater != null) {
+      topicBulkActionsUpdater.run();
     }
   }
 

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -3729,18 +3729,40 @@ public class CleverPush {
    * Recursively toggles every topic checkbox under {@code parentLayout} to the given state.
    * The unsubscribe checkbox (if present) is skipped so that its state is only updated by the
    * existing {@link #toggleCheckedTopic} side effects.
+   *
+   * <p>The checkboxes are snapshotted before any state change is applied because each
+   * {@link CheckBox#setChecked(boolean)} call may cascade into
+   * {@link #toggleCheckedTopic} and, when the last selected topic is removed, into the
+   * {@code unsubscribeCheckbox} listener which rebuilds the entire {@code parentLayout} via
+   * {@link #setTopicCheckboxList}. Iterating the live view hierarchy by index in that case
+   * would trigger an {@link IndexOutOfBoundsException} or skip / re-toggle freshly added
+   * children (CP-11581).</p>
    */
   private void setAllTopicCheckboxesChecked(ViewGroup parentLayout, CheckBox unsubscribeCheckbox,
                                             boolean checked) {
+    List<CheckBox> checkboxes = new ArrayList<>();
+    collectTopicCheckboxes(parentLayout, unsubscribeCheckbox, checkboxes);
+    for (CheckBox checkbox : checkboxes) {
+      checkbox.setChecked(checked);
+    }
+  }
+
+  /**
+   * Recursively collects every topic checkbox under {@code parentLayout} (excluding
+   * {@code unsubscribeCheckbox}) into {@code checkboxes}. This snapshot lets bulk actions
+   * iterate without being affected by view-hierarchy mutations triggered by listeners.
+   */
+  private void collectTopicCheckboxes(ViewGroup parentLayout, CheckBox unsubscribeCheckbox,
+                                      List<CheckBox> checkboxes) {
     for (int i = 0; i < parentLayout.getChildCount(); i++) {
       View child = parentLayout.getChildAt(i);
       if (child instanceof CheckBox) {
         if (child == unsubscribeCheckbox) {
           continue;
         }
-        ((CheckBox) child).setChecked(checked);
+        checkboxes.add((CheckBox) child);
       } else if (child instanceof ViewGroup) {
-        setAllTopicCheckboxesChecked((ViewGroup) child, unsubscribeCheckbox, checked);
+        collectTopicCheckboxes((ViewGroup) child, unsubscribeCheckbox, checkboxes);
       }
     }
   }

--- a/cleverpush/src/main/res/values-de/strings.xml
+++ b/cleverpush/src/main/res/values-de/strings.xml
@@ -11,6 +11,8 @@
     <string name="save">Speichern</string>
     <string name="topics_dialog_title">Abonnierte Themen</string>
     <string name="deselect_all">Alles abwählen</string>
+    <string name="select_all">Alle auswählen</string>
+    <string name="remove_all">Alle entfernen</string>
     <string name="geofence_transition_invalid_type">Ungültiger Geofence</string>
     <string name="no_notifications_available">Keine Nachrichten verfügbar</string>
 </resources>

--- a/cleverpush/src/main/res/values/strings.xml
+++ b/cleverpush/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="save">Save</string>
     <string name="topics_dialog_title">Subscribed Topics</string>
     <string name="deselect_all">Deselect everything</string>
+    <string name="select_all">Select All</string>
+    <string name="remove_all">Remove All</string>
     <string name="geofence_transition_invalid_type">Invalid geofence</string>
     <string name="no_notifications_available">No notifications available</string>
 </resources>


### PR DESCRIPTION
Show a "Select All" / "Remove All" header above the topic checkbox list when `topicsDialogBulkActions` is enabled in the channel config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription topic selection UI and bulk-toggle behavior; bugs could mis-sync selected topics before save, but scope is limited to the topics dialog.
> 
> **Overview**
> When **`topicsDialogBulkActions`** is enabled in channel config, the topics dialog shows a **Select All** / **Remove All** row above the checkbox list. Buttons grey out when the action would do nothing and refresh as selections change.
> 
> Bulk toggling snapshots topic checkboxes before updating them so listener-driven rebuilds of the list (including the unsubscribe “deselect all” path) do not cause crashes or wrong states (**CP-11581**).
> 
> **`confirmAlertSelectTopicsSaveText`** can override the positive button label; new **`select_all`** / **`remove_all`** strings were added for English and German.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32273dd387b1de0d6bdbd303c2f8028a19be8200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Select All / Remove All header to the topics dialog when `topicsDialogBulkActions` is enabled for quick bulk edits. Makes the enhanced topic selection popup configurable and safer (CP-11581).

- **New Features**
  - Buttons auto-disable on no-ops and stay in sync as selections change; bulk actions snapshot checkboxes to avoid view rebuild issues and skip the unsubscribe box; disabled styling adapts to night mode.
  - Added `confirmAlertSelectTopicsSaveText` to override the Save label; added localized `select_all` and `remove_all` strings (en/de).

<sup>Written for commit 32273dd387b1de0d6bdbd303c2f8028a19be8200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/351?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

