### PR TITLE
feature/cp-11619-android-implement-new-method-to-sync-piano-segments-for

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -4667,4 +4667,19 @@ public class CleverPush {
   public void setAppBannersNonBlocking(boolean appBannersNonBlocking) {
     this.appBannersNonBlocking = appBannersNonBlocking;
   }
+
+  public Set<String> getSubscriptionPianoSegments() {
+    return getSharedPreferences(getContext()).getStringSet(CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS, new HashSet<>());
+  }
+
+  public void setPianoSegments(String[] segments) {
+    SharedPreferences sharedPreferences = getSharedPreferences(getContext());
+    SharedPreferences.Editor editor = sharedPreferences.edit();
+    editor.remove(CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS).apply();
+    if (segments != null) {
+      editor.putStringSet(CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS, new HashSet<>(Arrays.asList(segments)));
+    }
+    editor.apply();
+    this.trySubscriptionSync();
+  }
 }

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -4675,8 +4675,9 @@ public class CleverPush {
   public void setPianoSegments(String[] segments) {
     SharedPreferences sharedPreferences = getSharedPreferences(getContext());
     SharedPreferences.Editor editor = sharedPreferences.edit();
-    editor.remove(CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS).apply();
-    if (segments != null) {
+    if (segments == null) {
+      editor.remove(CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS);
+    } else {
       editor.putStringSet(CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS, new HashSet<>(Arrays.asList(segments)));
     }
     editor.apply();

--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -48,5 +48,6 @@ public class CleverPushPreferences {
   public static final String APP_BANNER_PER_DAY = "CleverPush_APP_BANNER_PER_DAY";
   public static final String APP_BANNER_PER_SESSION = "CleverPush_APP_BANNER_PER_SESSION";
   public static final String INBOX_VIEW_NOTIFICATION_OPENED = "CleverPush_INBOX_VIEW_NOTIFICATION_OPENED";
+  public static final String SUBSCRIPTION_PIANO_SEGMENTS = "CleverPush_SUBSCRIPTION_PIANO_SEGMENTS";
 
 }

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerBase.java
@@ -97,6 +97,11 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
       }
     }
 
+    Set<String> pianoSegments = null;
+    if (sharedPreferences.contains(CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS)) {
+      pianoSegments = sharedPreferences.getStringSet(CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS, null);
+    }
+
     JSONObject jsonBody = new JSONObject();
     try {
       if (this.type == SubscriptionManagerType.ADM) {
@@ -133,6 +138,9 @@ abstract class SubscriptionManagerBase implements SubscriptionManager {
       if (topics != null) {
         jsonBody.put("topics", new JSONArray(topics));
         jsonBody.put("topicsVersion", topicsVersion);
+      }
+      if (pianoSegments != null) {
+        jsonBody.put("pianoSegments", new JSONArray(pianoSegments));
       }
       jsonBody.put("hasNotificationPermission", CleverPush.getInstance(CleverPush.context).areNotificationsEnabled());
     } catch (JSONException e) {


### PR DESCRIPTION
Implement `setPianoSegments` method to sync Piano segments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and optional sync payload field; no auth or breaking changes to existing subscription flow.
> 
> **Overview**
> Adds Android support for **Piano audience segments** on the CleverPush subscription, aligned with CP-11619.
> 
> **`CleverPush.setPianoSegments(String[] segments)`** stores segment IDs in `SharedPreferences` under `SUBSCRIPTION_PIANO_SEGMENTS`, clears them when `segments` is `null`, and calls **`trySubscriptionSync()`** so the backend is updated soon after a change. **`getSubscriptionPianoSegments()`** reads the stored set.
> 
> **`SubscriptionManagerBase`** includes a **`pianoSegments`** JSON array on **`/subscription/sync/{channelId}`** only when that preference key exists—same pattern as topics.
> 
> **Integration:** call `setPianoSegments` when Piano segment membership changes; pass `null` to remove segments from the device and stop sending them on sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 210a18190fd5b4544b391ca5119d5f0a18c9279f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new `CleverPush` APIs to store and sync Piano segments in the Android subscription payload. Aligns with Linear CP-11619.

- **New Features**
  - `CleverPush.setPianoSegments(String[] segments)`: persists segments and triggers `trySubscriptionSync`.
  - `CleverPush.getSubscriptionPianoSegments()`: returns the stored segments.
  - Persists under `CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS` and includes `pianoSegments` in `/subscription/sync` when present.

- **Migration**
  - Call `setPianoSegments(...)` whenever Piano segments change; pass `null` to clear.

<sup>Written for commit 210a18190fd5b4544b391ca5119d5f0a18c9279f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/352?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

