### PR TITLE
feature/cp-11685-flutter-sdk-extend-test-subscription-status-management

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -4795,10 +4795,22 @@ public class CleverPush {
   }
 
   public void markSubscriptionAsTest() {
-    markSubscriptionAsTest(null);
+    setSubscriptionTestStatus(null, true);
   }
 
   public void markSubscriptionAsTest(CompletionFailureListener listener) {
+    setSubscriptionTestStatus(listener, true);
+  }
+
+  public void unmarkSubscriptionAsTest() {
+    setSubscriptionTestStatus(null, false);
+  }
+
+  public void unmarkSubscriptionAsTest(CompletionFailureListener listener) {
+    setSubscriptionTestStatus(listener, false);
+  }
+
+  private void setSubscriptionTestStatus(CompletionFailureListener listener, boolean isTest) {
     try {
       String channelId = getChannelId(context);
       if (isChannelIdInvalid(channelId, "markSubscriptionAsTest"))
@@ -4813,6 +4825,7 @@ public class CleverPush {
       JSONObject jsonBody = new JSONObject();
       jsonBody.put("channelId", channelId);
       jsonBody.put("subscriptionId", subscriptionId);
+      jsonBody.put("isTest", isTest);
 
       String markAsTestPath = "/subscription/mark-as-test";
 


### PR DESCRIPTION
Added method `unmarkSubscriptionAsTest ` to unmark subscription as test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small public API addition on a single subscription helper; same endpoint with an explicit boolean—no auth or data-model changes.
> 
> **Overview**
> The Android SDK now supports **clearing** a subscription’s test flag, not only setting it.
> 
> `markSubscriptionAsTest` overloads delegate to a new private **`setSubscriptionTestStatus`**, which POSTs to `/subscription/mark-as-test` with **`isTest`** in the JSON body (`true` when marking, `false` when unmarking). Public **`unmarkSubscriptionAsTest`** and **`unmarkSubscriptionAsTest(CompletionFailureListener)`** mirror the existing mark APIs.
> 
> This extends test-subscription management for cross-platform SDK use (e.g. Flutter) without changing the HTTP path or response handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f245fb081f9ebfdc9545efcf67c3b4799b558e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ability to unmark a subscription as test and unifies test status updates behind a single helper. Extends test subscription status management to meet Linear CP-11685 for the Flutter SDK.

- **New Features**
  - New methods to revert test status: unmarkSubscriptionAsTest() and unmarkSubscriptionAsTest(CompletionFailureListener).

- **Refactors**
  - markSubscriptionAsTest now delegates to setSubscriptionTestStatus(listener, isTest), sending isTest in the request to /subscription/mark-as-test.

<sup>Written for commit 2f245fb081f9ebfdc9545efcf67c3b4799b558e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

