### PR TITLE
feature/cp-11715-add-exist-and-does-not-exist-logic-to-attributes-android

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -752,7 +752,7 @@ public class AppBannerModule {
                     : !exists;
           } catch (JSONException e) {
             Logger.e(TAG, "isBannerAttributeTargetingAllowed: Error parsing subscription attributes Exists/NotExists relation.", e);
-            currentMatch = relation == CheckFilterRelation.NotExists;
+            currentMatch = false;
           }
         } else if (relation == CheckFilterRelation.ContainsSubstring) {
           if (attributeValueObj instanceof String) {

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -736,7 +736,25 @@ public class AppBannerModule {
         Object attributeValueObj = getCleverPushInstance().getSubscriptionAttribute(attributeId);
         boolean currentMatch = false;
 
-        if (relation == CheckFilterRelation.ContainsSubstring) {
+        if (relation == CheckFilterRelation.Exists
+                || relation == CheckFilterRelation.NotExists) {
+          try {
+            String jsonString = sharedPreferences.getString(
+                    CleverPushPreferences.SUBSCRIPTION_ATTRIBUTES,
+                    new JSONObject().toString()
+            );
+
+            JSONObject attributes = new JSONObject(jsonString);
+            boolean exists = attributes.has(attributeId);
+
+            currentMatch = relation == CheckFilterRelation.Exists
+                    ? exists
+                    : !exists;
+          } catch (JSONException e) {
+            Logger.e(TAG, "isBannerAttributeTargetingAllowed: Error parsing subscription attributes Exists/NotExists relation.", e);
+            currentMatch = relation == CheckFilterRelation.NotExists;
+          }
+        } else if (relation == CheckFilterRelation.ContainsSubstring) {
           if (attributeValueObj instanceof String) {
             currentMatch = ((String) attributeValueObj).contains(compareAttributeValue);
           } else if (attributeValueObj instanceof JSONArray) {

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -736,25 +736,22 @@ public class AppBannerModule {
         Object attributeValueObj = getCleverPushInstance().getSubscriptionAttribute(attributeId);
         boolean currentMatch = false;
 
-        if (relation == CheckFilterRelation.Exists) {
-          String jsonString =
-                  sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ATTRIBUTES, (new JSONObject()).toString());
+        if (relation == CheckFilterRelation.Exists
+                || relation == CheckFilterRelation.NotExists) {
           try {
+            String jsonString = sharedPreferences.getString(
+                    CleverPushPreferences.SUBSCRIPTION_ATTRIBUTES,
+                    new JSONObject().toString()
+            );
+
             JSONObject attributes = new JSONObject(jsonString);
-            currentMatch = attributes.has(attributeId);
+            boolean exists = attributes.has(attributeId);
+
+            currentMatch = relation == CheckFilterRelation.Exists
+                    ? exists
+                    : !exists;
           } catch (JSONException e) {
-            Logger.e(TAG, "isBannerAttributeTargetingAllowed: Error parsing subscription attributes for Exists relation", e);
-            return false;
-          }
-        } else if (relation == CheckFilterRelation.NotExists) {
-          String jsonString =
-                  sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ATTRIBUTES, (new JSONObject()).toString());
-          try {
-            JSONObject attributes = new JSONObject(jsonString);
-            currentMatch = !attributes.has(attributeId);
-          } catch (JSONException e) {
-            Logger.e(TAG, "isBannerAttributeTargetingAllowed: Error parsing subscription attributes for NotExists relation.", e);
-            currentMatch = false;
+            Logger.e(TAG, "isBannerAttributeTargetingAllowed: Error parsing subscription attributes Exists/NotExists relation.", e);
           }
         } else if (relation == CheckFilterRelation.ContainsSubstring) {
           if (attributeValueObj instanceof String) {

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -754,7 +754,7 @@ public class AppBannerModule {
             currentMatch = !attributes.has(attributeId);
           } catch (JSONException e) {
             Logger.e(TAG, "isBannerAttributeTargetingAllowed: Error parsing subscription attributes for NotExists relation.", e);
-            currentMatch = true;
+            currentMatch = false;
           }
         } else if (relation == CheckFilterRelation.ContainsSubstring) {
           if (attributeValueObj instanceof String) {

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -736,23 +736,25 @@ public class AppBannerModule {
         Object attributeValueObj = getCleverPushInstance().getSubscriptionAttribute(attributeId);
         boolean currentMatch = false;
 
-        if (relation == CheckFilterRelation.Exists
-                || relation == CheckFilterRelation.NotExists) {
+        if (relation == CheckFilterRelation.Exists) {
+          String jsonString =
+                  sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ATTRIBUTES, (new JSONObject()).toString());
           try {
-            String jsonString = sharedPreferences.getString(
-                    CleverPushPreferences.SUBSCRIPTION_ATTRIBUTES,
-                    new JSONObject().toString()
-            );
-
             JSONObject attributes = new JSONObject(jsonString);
-            boolean exists = attributes.has(attributeId);
-
-            currentMatch = relation == CheckFilterRelation.Exists
-                    ? exists
-                    : !exists;
+            currentMatch = attributes.has(attributeId);
           } catch (JSONException e) {
-            Logger.e(TAG, "isBannerAttributeTargetingAllowed: Error parsing subscription attributes Exists/NotExists relation.", e);
-            currentMatch = false;
+            Logger.e(TAG, "isBannerAttributeTargetingAllowed: Error parsing subscription attributes for Exists relation", e);
+            return false;
+          }
+        } else if (relation == CheckFilterRelation.NotExists) {
+          String jsonString =
+                  sharedPreferences.getString(CleverPushPreferences.SUBSCRIPTION_ATTRIBUTES, (new JSONObject()).toString());
+          try {
+            JSONObject attributes = new JSONObject(jsonString);
+            currentMatch = !attributes.has(attributeId);
+          } catch (JSONException e) {
+            Logger.e(TAG, "isBannerAttributeTargetingAllowed: Error parsing subscription attributes for NotExists relation.", e);
+            currentMatch = true;
           }
         } else if (relation == CheckFilterRelation.ContainsSubstring) {
           if (attributeValueObj instanceof String) {

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/CheckFilterRelation.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/CheckFilterRelation.java
@@ -11,7 +11,9 @@ public enum CheckFilterRelation {
   NotEqual,
   Contains,
   NotContains,
-  ContainsSubstring;
+  ContainsSubstring,
+  Exists,
+  NotExists;
 
   private static final Map<String, CheckFilterRelation> relations = new HashMap<>();
 
@@ -24,6 +26,8 @@ public enum CheckFilterRelation {
     relations.put("contains", CheckFilterRelation.Contains);
     relations.put("notContains", CheckFilterRelation.NotContains);
     relations.put("containsSubstring", CheckFilterRelation.ContainsSubstring);
+    relations.put("exists", CheckFilterRelation.Exists);
+    relations.put("notExists", CheckFilterRelation.NotExists);
   }
 
   public static CheckFilterRelation fromString(String raw) {


### PR DESCRIPTION
Added a new Attribute condition type in Targeting for `AppBanner`: Exists/NotExists

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to banner attribute filter evaluation with no auth or network impact; wrong key presence logic could only mis-target banners.
> 
> **Overview**
> **App banner attribute targeting** can now use **Exists** and **NotExists** relations (`exists` / `notExists` on `CheckFilterRelation`), so campaigns can target subscribers by whether a given attribute **key** is present, not only by value comparisons.
> 
> In `isBannerAttributeTargetingAllowed`, those relations read `SUBSCRIPTION_ATTRIBUTES` from shared preferences and set a match from `JSONObject.has(attributeId)`; **NotExists** inverts that. Parse failures leave `currentMatch` false (same as other relations on error). Existing value-based relations are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73eaaa7ddec1219fa84684bd8f9ecd37c9d56c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Exists/NotExists attribute targeting for `AppBanner` on Android so campaigns can match when a subscription attribute key is present or absent. Satisfies Linear CP-11715.

- **New Features**
  - Added `Exists` and `NotExists` to `CheckFilterRelation` with string keys `exists` and `notExists`.
  - In `isBannerAttributeTargetingAllowed`, read `SUBSCRIPTION_ATTRIBUTES` and check `JSONObject.has(attributeId)`; on JSON parse error neither relation matches.

<sup>Written for commit 73eaaa7ddec1219fa84684bd8f9ecd37c9d56c04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

