### PR TITLE
hotfix/cp-11582-visiolink-push-banner-is-not-being-desplay

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
+++ b/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
@@ -87,9 +87,6 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
     }
 
     try {
-      // Only flush the queued listeners once a real host activity is resumed.
-      // The transient NotificationOpenedActivity trampoline calls finish() in onCreate,
-      // so firing listeners against it would bind banners/dialogs to a dying activity.
       if (isValidHostActivity(activity)
           && activityInitializedListeners != null && activityInitializedListeners.size() > 0) {
         for (ActivityInitializedListener listener : activityInitializedListeners) {
@@ -183,9 +180,6 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
   public void setActivityInitializedListener(ActivityInitializedListener activityInitializedListener) {
 
     if (!isValidHostActivity(currentActivity)) {
-      // No real host activity yet (null, finishing, destroyed, or the transient
-      // NotificationOpenedActivity trampoline). Queue the listener so it runs when a
-      // proper activity is resumed instead of binding to a dying activity.
       if (activityInitializedListeners == null) {
         activityInitializedListeners = new ArrayList<>();
       }
@@ -205,10 +199,6 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
       return false;
     }
     if (activity instanceof NotificationOpenedActivity) {
-      // In the default (non-callback) flow this trampoline calls finish() right after
-      // processing the intent, so it is not a usable host - defer until the real activity
-      // resumes. In NotificationOpenedCallbackListener mode it is intentionally kept alive,
-      // so we preserve the previous behavior and treat it as a valid host.
       try {
         if (!CleverPush.getInstance(CleverPush.context).isUsingNotificationOpenedCallbackListener()) {
           return false;

--- a/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
+++ b/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
@@ -8,6 +8,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -86,7 +87,11 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
     }
 
     try {
-      if (activityInitializedListeners != null && activityInitializedListeners.size() > 0) {
+      // Only flush the queued listeners once a real host activity is resumed.
+      // The transient NotificationOpenedActivity trampoline calls finish() in onCreate,
+      // so firing listeners against it would bind banners/dialogs to a dying activity.
+      if (isValidHostActivity(activity)
+          && activityInitializedListeners != null && activityInitializedListeners.size() > 0) {
         for (ActivityInitializedListener listener : activityInitializedListeners) {
           listener.initialized();
         }
@@ -177,7 +182,10 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
 
   public void setActivityInitializedListener(ActivityInitializedListener activityInitializedListener) {
 
-    if (currentActivity == null) {
+    if (!isValidHostActivity(currentActivity)) {
+      // No real host activity yet (null, finishing, destroyed, or the transient
+      // NotificationOpenedActivity trampoline). Queue the listener so it runs when a
+      // proper activity is resumed instead of binding to a dying activity.
       if (activityInitializedListeners == null) {
         activityInitializedListeners = new ArrayList<>();
       }
@@ -185,6 +193,37 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
     } else {
       activityInitializedListener.initialized();
     }
+  }
+
+  /**
+   * Determines whether the given activity is a valid host for showing UI (banners, dialogs, etc.).
+   * The CleverPush NotificationOpenedActivity is a trampoline that finishes itself immediately,
+   * so it must not be treated as a usable host.
+   */
+  static boolean isValidHostActivity(Activity activity) {
+    if (activity == null) {
+      return false;
+    }
+    if (activity instanceof NotificationOpenedActivity) {
+      // In the default (non-callback) flow this trampoline calls finish() right after
+      // processing the intent, so it is not a usable host - defer until the real activity
+      // resumes. In NotificationOpenedCallbackListener mode it is intentionally kept alive,
+      // so we preserve the previous behavior and treat it as a valid host.
+      try {
+        if (!CleverPush.getInstance(CleverPush.context).isUsingNotificationOpenedCallbackListener()) {
+          return false;
+        }
+      } catch (Throwable ignored) {
+        return false;
+      }
+    }
+    if (activity.isFinishing()) {
+      return false;
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed()) {
+      return false;
+    }
+    return true;
   }
 
   @Nullable

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -640,7 +640,12 @@ public class CleverPush {
           }
 
           if (this.appBannerModule != null && this.getCurrentActivity() != null) {
-            this.appBannerModule.initSession(channelId);
+            String sessionChannelId = this.channelId;
+            if (sessionChannelId == null || sessionChannelId.isEmpty()) {
+              sessionChannelId = getSharedPreferences(getContext())
+                      .getString(CleverPushPreferences.CHANNEL_ID, null);
+            }
+            this.appBannerModule.initSession(sessionChannelId);
           } else if (this.getCurrentActivity() == null) {
             Logger.e(LOG_TAG, "getCurrentActivity() is null");
           }
@@ -4169,6 +4174,7 @@ public class CleverPush {
       editor.remove(CleverPushPreferences.SUBSCRIPTION_ID);
       editor.remove(CleverPushPreferences.SUBSCRIPTION_LAST_SYNC);
       editor.remove(CleverPushPreferences.SUBSCRIPTION_CREATED_AT);
+      editor.remove(CleverPushPreferences.SUBSCRIPTION_PIANO_SEGMENTS);
       if (!this.keepTargetingDataOnUnsubscribe) {
         editor.remove(CleverPushPreferences.SUBSCRIPTION_TOPICS);
         editor.remove(CleverPushPreferences.SUBSCRIPTION_TOPICS_VERSION);

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -225,11 +225,13 @@ public class AppBannerModule {
     if (fromNotification) {
       if (isLoadingNotificationBanners()) {
         pendingBannerAPI.add(notificationId);
+        isBannerRequestRunning = false;
         return;
       }
       setLoadingNotificationBanners(true);
     } else {
       if (isLoadingDefaultBanners()) {
+        isBannerRequestRunning = false;
         return;
       }
       setLoadingDefaultBanners(true);
@@ -349,7 +351,7 @@ public class AppBannerModule {
           setLoadingNotificationBanners(false);
           processNextBannerRequest(true);
         } else {
-          defaultBannersLoaded = false;
+          defaultBannersLoaded = true;
           setLoadingDefaultBanners(false);
           processNextBannerRequest(false);
         }

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -398,8 +398,8 @@ public class AppBannerModule {
     isBannerRequestRunning = false;
 
     loadBanners(
-            nextRequest.notificationId,
-            nextRequest.channelId
+            nextRequest.getNotificationId(),
+            nextRequest.getChannelId()
     );
   }
 

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -34,6 +34,7 @@ import com.cleverpush.banner.models.BannerTriggerConditionEventProperty;
 import com.cleverpush.banner.models.BannerTriggerConditionType;
 import com.cleverpush.banner.models.BannerTriggerType;
 import com.cleverpush.banner.models.CheckFilterRelation;
+import com.cleverpush.banner.models.PendingBannerRequest;
 import com.cleverpush.banner.models.PlatformType;
 import com.cleverpush.banner.models.VersionComparison;
 import com.cleverpush.database.DatabaseClient;
@@ -66,6 +67,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -86,13 +88,15 @@ public class AppBannerModule {
   private String channel;
   private long lastSessionTimestamp;
   private int sessions;
-  private boolean loading = false;
+  private boolean loadingDefaultBanners = false;
+  private boolean loadingNotificationBanners = false;
   private Collection<AppBannerPopup> filteredBanners = new ArrayList<>();
   private Collection<AppBannerPopup> pendingBanners = new ArrayList<>();
   private LinkedList<AppBannerPopup> pendingFilteredBanners = new LinkedList<>();
   private Collection<Banner> allBanners = new LinkedList<>();
   private Collection<Banner> allNotificationBanners = new LinkedList<>();
   private Collection<AppBannersListener> bannersListeners = new ArrayList<>();
+  private Collection<AppBannersListener> notificationBannersListeners = new ArrayList<>();
   private boolean trackingEnabled = true;
   HashMap<String, String> currentVoucherCodePlaceholder = new HashMap<>();
   public boolean isInitSessionCalled = false;
@@ -107,6 +111,9 @@ public class AppBannerModule {
   private TriggeredEvent currentEvent = null;
   private AppBannerClosedListener appBannerClosedListener;
   Set<String> shownBanners = new HashSet<>();
+  private final Queue<PendingBannerRequest> pendingBannerRequests = new LinkedList<>();
+  private boolean isBannerRequestRunning = false;
+  private boolean defaultBannersLoaded = false;
 
   private AppBannerModule(String channel, boolean showDrafts, SharedPreferences sharedPreferences,
                           SharedPreferences.Editor editor) {
@@ -198,18 +205,37 @@ public class AppBannerModule {
 
   synchronized void loadBanners(String notificationId, String channelId) {
     if (channelId == null || channelId.isEmpty()) {
-      Logger.w(TAG, "loadBanners: Channel ID is null or empty.");
+      channelId = getCleverPushInstance().getChannelId(getCleverPushInstance().getContext());
+    }
+
+    if (isChannelIdInvalid(channelId, "loadBanners"))
+      return;
+
+    if (isBannerRequestRunning) {
+      pendingBannerRequests.add(
+              new PendingBannerRequest(notificationId, channelId)
+      );
       return;
     }
 
-    if (isLoading()) {
-      if (notificationId != null) {
+    isBannerRequestRunning = true;
+
+    boolean fromNotification = notificationId != null && !notificationId.isEmpty();
+
+    if (fromNotification) {
+      if (isLoadingNotificationBanners()) {
         pendingBannerAPI.add(notificationId);
+        return;
       }
-      return;
+      setLoadingNotificationBanners(true);
+    } else {
+      if (isLoadingDefaultBanners()) {
+        return;
+      }
+      setLoadingDefaultBanners(true);
+      defaultBannersLoaded = true;
     }
 
-    setLoading(true);
     String bannersPath = "/channel/" + channelId + "/app-banners?platformName=Android";
     if (getCleverPushInstance().isDevelopmentModeEnabled()) {
       bannersPath += "&t=" + System.currentTimeMillis();
@@ -225,7 +251,6 @@ public class AppBannerModule {
     CleverPushHttpClient.getWithRetry(bannersPath, new CleverPushHttpClient.ResponseHandler() {
       @Override
       public void onSuccess(String response) {
-        setLoading(false);
         allBanners = new LinkedList<>();
         allNotificationBanners = new LinkedList<>();
         try {
@@ -289,15 +314,17 @@ public class AppBannerModule {
             allBanners.addAll(bannerList);
           }
 
-          for (AppBannersListener listener : getBannersListeners()) {
-            if (finalFromNotification) {
+          if (finalFromNotification) {
+            for (AppBannersListener listener : new ArrayList<>(getNotificationBannersListeners())) {
               listener.ready(allNotificationBanners);
-            } else {
+            }
+            notificationBannersListeners = new ArrayList<>();
+          } else {
+            for (AppBannersListener listener : getBannersListeners()) {
               listener.ready(allBanners);
             }
+            bannersListeners = new ArrayList<>();
           }
-
-          bannersListeners = new ArrayList<>();
         } catch (Exception ex) {
           Logger.e(TAG, "Error in sorting AppBanners." + ex.getMessage(), ex);
         }
@@ -318,11 +345,26 @@ public class AppBannerModule {
         }
 
         showSilentNotificationBanners();
+        if (finalFromNotification) {
+          setLoadingNotificationBanners(false);
+          processNextBannerRequest(true);
+        } else {
+          defaultBannersLoaded = false;
+          setLoadingDefaultBanners(false);
+          processNextBannerRequest(false);
+        }
       }
 
       @Override
       public void onFailure(int statusCode, String response, Throwable throwable) {
-        setLoading(false);
+        if (finalFromNotification) {
+          setLoadingNotificationBanners(false);
+          processNextBannerRequest(true);
+        } else {
+          defaultBannersLoaded = false;
+          setLoadingDefaultBanners(false);
+          processNextBannerRequest(false);
+        }
         if (throwable != null) {
           Logger.e("CleverPush", "Something went wrong when loading banners." +
                   "\nStatus code: " + statusCode +
@@ -340,12 +382,33 @@ public class AppBannerModule {
     });
   }
 
+  private synchronized void processNextBannerRequest(boolean isBannerFromNotification) {
+    PendingBannerRequest nextRequest =
+            pendingBannerRequests.poll();
+
+    if (nextRequest == null) {
+      isBannerRequestRunning = false;
+
+      if (isBannerFromNotification && !defaultBannersLoaded && !isLoadingDefaultBanners()) {
+        loadBanners(null, channel);
+      }
+      return;
+    }
+
+    isBannerRequestRunning = false;
+
+    loadBanners(
+            nextRequest.notificationId,
+            nextRequest.channelId
+    );
+  }
+
   /**
    * Displays silent notification banners based on stored preferences.
    * Retrieves silent push banner info from preferences, iterates through entries,
    * and shows corresponding banners using showBanner. Updates preferences after each display.
    */
-  private void showSilentNotificationBanners() {
+  void showSilentNotificationBanners() {
     try {
       String silentPushBanners = sharedPreferences.getString(CleverPushPreferences.SILENT_PUSH_APP_BANNER, null);
 
@@ -353,7 +416,11 @@ public class AppBannerModule {
         Type type = new TypeToken<Map<String, String>>() {}.getType();
         Map<String, String> silentPushBannersMap = new Gson().fromJson(silentPushBanners, type);
 
-        for (Map.Entry<String, String> entry : silentPushBannersMap.entrySet()) {
+        if (silentPushBannersMap == null || silentPushBannersMap.isEmpty()) {
+          return;
+        }
+
+        for (Map.Entry<String, String> entry : new ArrayList<>(silentPushBannersMap.entrySet())) {
           String silentNotificationId = entry.getKey();
           String silentBannerId = entry.getValue();
 
@@ -375,6 +442,13 @@ public class AppBannerModule {
                                          String blockId, String screenId, boolean isElementAlreadyClicked, boolean isScreenAlreadyShown) {
     JSONObject jsonBody = getJsonObject();
     try {
+      if (this.channel == null || this.channel.isEmpty()) {
+        this.channel = getCleverPushInstance().getChannelId(getCleverPushInstance().getContext());
+      }
+
+      if (isChannelIdInvalid(this.channel, "sendBannerEvent"))
+        return;
+
       if (this.channel == null || this.channel.isEmpty()) {
         Logger.w(TAG, "sendBannerEvent: Channel ID is null or empty.");
         return;
@@ -432,10 +506,19 @@ public class AppBannerModule {
   }
 
   public void initSession(String channel) {
+    Logger.d("CleverPush", "[Loading banners initSession2");
     initSession(channel, false);
   }
 
   public void initSession(String channel, boolean isChannelIdChanged) {
+    if (channel != null && !channel.isEmpty()) {
+      this.channel = channel;
+    }
+
+    if (isChannelIdInvalid(this.channel, "initSession")) {
+      return;
+    }
+
     if (isInitSessionCalled && !isChannelIdChanged) {
       return;
     }
@@ -443,11 +526,11 @@ public class AppBannerModule {
 
     events.clear();
 
-    this.channel = channel;
     if (!getCleverPushInstance().isDevelopmentModeEnabled()
             && lastSessionTimestamp > 0
             && (System.currentTimeMillis() - lastSessionTimestamp) < MIN_SESSION_LENGTH
             && !isChannelIdChanged) {
+      showSilentNotificationBanners();
       return;
     }
 
@@ -465,6 +548,7 @@ public class AppBannerModule {
     this.saveSessions();
     allBanners = null;
     allNotificationBanners = null;
+    defaultBannersLoaded = false;
     handler.post(this::loadBanners);
 
     this.startup();
@@ -542,7 +626,7 @@ public class AppBannerModule {
     if (notificationId != null) {
       getHandler().post(() -> {
         this.loadBanners(notificationId, channel);
-        bannersListeners.add(listener);
+        notificationBannersListeners.add(listener);
       });
     } else {
       if (getListOfBanners() == null) {
@@ -1723,18 +1807,20 @@ public class AppBannerModule {
         getBanners(banners -> {
           for (Banner banner : banners) {
             if (banner.getId().equals(bannerId)) {
-              AppBannerPopup popup = getAppBannerPopup(banner);
+              getActivityLifecycleListener().setActivityInitializedListener(() -> {
+                AppBannerPopup popup = getAppBannerPopup(banner);
 
-              if (getCleverPushInstance().isAppBannersDisabled()) {
-                pendingBanners.add(popup);
-                break;
-              }
+                if (getCleverPushInstance().isAppBannersDisabled()) {
+                  pendingBanners.add(popup);
+                  return;
+                }
 
-              if (notificationId != null && !notificationId.isEmpty() && banner.getTriggers().size() > 0) {
-                validatePushBannerTrigger(banner, popup, force, appBannerClosedListener, notificationId);
-              } else {
-                getHandler().post(() -> showBanner(popup, force, appBannerClosedListener, notificationId));
-              }
+                if (notificationId != null && !notificationId.isEmpty() && banner.getTriggers().size() > 0) {
+                  validatePushBannerTrigger(banner, popup, force, appBannerClosedListener, notificationId);
+                } else {
+                  getHandler().post(() -> showBanner(popup, force, appBannerClosedListener, notificationId));
+                }
+              });
               break;
             }
           }
@@ -2129,12 +2215,20 @@ public class AppBannerModule {
     return lastSessionTimestamp;
   }
 
-  public boolean isLoading() {
-    return loading;
+  public boolean isLoadingDefaultBanners() {
+    return loadingDefaultBanners;
   }
 
-  public void setLoading(boolean loading) {
-    this.loading = loading;
+  public void setLoadingDefaultBanners(boolean loadingDefaultBanners) {
+    this.loadingDefaultBanners = loadingDefaultBanners;
+  }
+
+  public boolean isLoadingNotificationBanners() {
+    return loadingNotificationBanners;
+  }
+
+  public void setLoadingNotificationBanners(boolean loadingNotificationBanners) {
+    this.loadingNotificationBanners = loadingNotificationBanners;
   }
 
   public Collection<Banner> getListOfBanners() {
@@ -2161,8 +2255,13 @@ public class AppBannerModule {
     return bannersListeners;
   }
 
+  public Collection<AppBannersListener> getNotificationBannersListeners() {
+    return notificationBannersListeners;
+  }
+
   public void clearBannersListeners() {
     bannersListeners.clear();
+    notificationBannersListeners.clear();
   }
 
   public JSONObject getJsonObject() {
@@ -2290,5 +2389,13 @@ public class AppBannerModule {
 
   public void setAppBannerClosedListener(AppBannerClosedListener appBannerClosedListener) {
     this.appBannerClosedListener = appBannerClosedListener;
+  }
+
+  private boolean isChannelIdInvalid(String channelId, String methodName) {
+    if (channelId == null || channelId.isEmpty()) {
+      Logger.w(TAG, methodName + ": Channel ID is null or empty.");
+      return true;
+    }
+    return false;
   }
 }

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
@@ -69,6 +69,8 @@ public class AppBannerPopup {
 
   private final int TAB_LAYOUT_DEFAULT_HEIGHT = 48;
   private final int MAIN_LAYOUT_PADDING = 15;
+  private static final int MAX_SHOW_RETRIES = 50;
+  private static final long SHOW_RETRY_DELAY_MS = 100L;
   private final Handler mainHandler;
   private Activity activity;
   private final Banner data;
@@ -79,9 +81,6 @@ public class AppBannerPopup {
   public FrameLayout frameLayout;
   public  ConstraintLayout parent;
   private ImageView bannerBackGroundImage;
-  private int currentStatusBarColor;
-  private int currentNavigationBarColor;
-  private boolean isNotchColorChange = false;
 
   private AppBannerOpenedListener openedListener;
   int currentDisplayedPagePosition;
@@ -95,7 +94,8 @@ public class AppBannerPopup {
     this.activity = activity;
     this.data = data;
 
-    mainHandler = new CustomExceptionHandler(activity.getMainLooper());
+    Looper looper = activity != null ? activity.getMainLooper() : Looper.getMainLooper();
+    mainHandler = new CustomExceptionHandler(looper);
   }
 
   private static SpringForce getDefaultForce(float finalValue) {
@@ -257,7 +257,7 @@ public class AppBannerPopup {
     if (!isInitialized) {
       throw new IllegalStateException("Must be initialized");
     }
-    new tryShowSafe().execute();
+    new tryShowSafe(0).execute();
   }
 
   public void dismiss() {
@@ -755,21 +755,26 @@ public class AppBannerPopup {
   }
 
   public class tryShowSafe extends AsyncTask<String, Void, Boolean> {
+    private final int attempt;
+
+    public tryShowSafe(int attempt) {
+      this.attempt = attempt;
+    }
+
     @Override
     protected Boolean doInBackground(String... strings) {
       if (isRootReady()) {
         return true;
       }
-      // Only reschedule if the activity is still valid (not finishing/destroyed)
-      if (activity != null
-          && !activity.isFinishing()
-          && (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1 || !activity.isDestroyed())) {
+      if (attempt < MAX_SHOW_RETRIES) {
         new Timer().schedule(new TimerTask() {
           @Override
           public void run() {
-            new tryShowSafe().execute();
+            new tryShowSafe(attempt + 1).execute();
           }
-        }, 100);
+        }, SHOW_RETRY_DELAY_MS);
+      } else {
+        Logger.i(TAG, "AppBanner not shown: no valid host activity became available after retries.");
       }
       return false;
     }

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/PendingBannerRequest.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/PendingBannerRequest.java
@@ -1,0 +1,11 @@
+package com.cleverpush.banner.models;
+
+public class PendingBannerRequest {
+  public String notificationId;
+  public String channelId;
+
+  public PendingBannerRequest(String notificationId, String channelId) {
+    this.notificationId = notificationId;
+    this.channelId = channelId;
+  }
+}

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/PendingBannerRequest.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/PendingBannerRequest.java
@@ -1,11 +1,19 @@
 package com.cleverpush.banner.models;
 
 public class PendingBannerRequest {
-  public String notificationId;
-  public String channelId;
+  private final String notificationId;
+  private final String channelId;
 
   public PendingBannerRequest(String notificationId, String channelId) {
     this.notificationId = notificationId;
     this.channelId = channelId;
+  }
+
+  public String getNotificationId() {
+    return notificationId;
+  }
+
+  public String getChannelId() {
+    return channelId;
   }
 }

--- a/cleverpush/src/test/java/com/cleverpush/banner/AppBannerModuleTest.java
+++ b/cleverpush/src/test/java/com/cleverpush/banner/AppBannerModuleTest.java
@@ -360,7 +360,7 @@ class AppBannerModuleTest {
         Collection<AppBannersListener> bannersListeners = new ArrayList<>();
         bannersListeners.add(appBannersListener);
 
-        doReturn(bannersListeners).when(appBannerModule).getBannersListeners();
+        doReturn(bannersListeners).when(appBannerModule).getNotificationBannersListeners();
         doReturn(cleverPush).when(appBannerModule).getCleverPushInstance();
         doReturn(cleverPush).when(appBannerModule).getCleverPushInstance();
         doReturn(true).when(cleverPush).isDevelopmentModeEnabled();
@@ -469,7 +469,7 @@ class AppBannerModuleTest {
 
         appBannerModule.getBanners(appBannersListener, "notificationId");
 
-        assertThat(appBannerModule.getBannersListeners().size()).isEqualTo(1);
+        assertThat(appBannerModule.getNotificationBannersListeners().size()).isEqualTo(1);
         verify(appBannerModule).loadBanners("notificationId", "channelId");
     }
 


### PR DESCRIPTION
Fix app banners not appearing when a banner-carrying push is tapped from the background

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core app-banner lifecycle, activity callbacks, and concurrent network loading paths used on every notification open; behavior changes are intentional but broad across the SDK.
> 
> **Overview**
> Fixes **push-triggered app banners not showing** when a notification is opened from the background (CP-11582).
> 
> **Activity readiness:** Adds `isValidHostActivity()` so `ActivityInitializedListener` callbacks run only on a real host activity—not on finishing/destroyed activities or the short-lived `NotificationOpenedActivity` trampoline (except when using the notification-opened callback mode). `showBannerById` now waits on that listener before presenting UI.
> 
> **Banner loading:** Replaces a single `loading` flag with separate **default vs notification** loads, a **request queue** (`PendingBannerRequest`), and `processNextBannerRequest()` so concurrent fetches serialize cleanly; after a notification fetch, default banners load automatically if they were skipped. Notification `getBanners` listeners are tracked separately from default listeners.
> 
> **Resilience:** Session init and banner APIs **fall back to channel ID from prefs** when missing; silent push banners are shown on short sessions and iterated safely. `AppBannerPopup` caps show retries (50 × 100ms) with a safe main looper. Unsubscribe clears **`SUBSCRIPTION_PIANO_SEGMENTS`** from prefs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f29d74e75fcf66bb9a1cdc4fc2cb604abc10922d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes push app banners not showing when a banner-carrying notification is opened from the background. Addresses CP-11582 by delaying banner UI until a valid host activity is ready and by serializing banner loads with separate default/notification paths.

- **Bug Fixes**
  - Only fire activity-initialized callbacks when a valid host is resumed; treat `NotificationOpenedActivity` as valid only in callback mode and ignore finishing/destroyed activities.
  - Serialize banner fetches via a request queue with separate default vs notification loading flags; auto-load default banners after a notification fetch if not yet loaded.
  - Split listeners for default vs notification banners; notify and clear only the relevant set.
  - Resolve and validate channel ID (prefs fallback) before session init, loads, and banner events; short sessions still flush stored silent push banners.
  - Show stored silent push banners safely after loads; iterate defensively and remove entries as they are shown.
  - Make display safer: `showBannerById` waits for activity readiness; `AppBannerPopup` uses a safe main looper and caps show retries (50x/100ms).
  - Clear `SUBSCRIPTION_PIANO_SEGMENTS` on unsubscribe.

<sup>Written for commit f29d74e75fcf66bb9a1cdc4fc2cb604abc10922d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

