### PR TITLE
hotfix/cp-11871-android-scrollable-background-renders-gray

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
@@ -233,6 +233,10 @@ public class AppBannerPopup {
         parent.setAlpha(0.0f);
       }
 
+      if (isNonBlockingAppBanners) {
+        parent.setBackgroundColor(Color.TRANSPARENT);
+      }
+
       bannerBackGroundImage.setVisibility(View.VISIBLE);
       composeBackground(bannerBackGroundImage, body, data.getBackground());
     }


### PR DESCRIPTION
Fixed an issue where, when non-blocking mode was enabled, a gray background was shown instead of the configured background color.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional UI background change in banner initialization with no auth, data, or API impact.
> 
> **Overview**
> Fixes a **gray backdrop** on native (non-HTML) app banners when **non-blocking** mode is on.
> 
> In `AppBannerPopup.init()`, for non-HTML banners the code already applies the configured background via `composeBackground` on `bannerBackGroundImage` and `body`. The root `parent` constraint layout could still show a default/opaque fill outside the banner chrome. The PR sets **`parent` to transparent** when `isNonBlockingAppBanners` is true, matching the intent of non-blocking overlays so only the composed banner background is visible—not a gray full-area layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91aa7bc595985e32eced52a3bd33bad7e6ded507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CP-11871: On Android, non-blocking app banners no longer render a gray background; they now show the configured background color or image. We set the parent view background to transparent when non-blocking mode is enabled.

<sup>Written for commit 91aa7bc595985e32eced52a3bd33bad7e6ded507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

