### PR TITLE
feature/cp-11668-add-button-border-customization-for-in-app-banners-android

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -15,6 +15,7 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.LayerDrawable;
+import android.os.Build;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
@@ -408,7 +409,7 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     boolean isDashed = borderStyle != null && borderStyle.equalsIgnoreCase("dashed");
     boolean isDotted = borderStyle != null && borderStyle.equalsIgnoreCase("dotted");
 
-    if (isDashed || isDotted) {
+    if ((isDashed || isDotted) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       button.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
 
       GradientDrawable borderDrawable = new GradientDrawable();

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -12,7 +12,9 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.LayerDrawable;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
@@ -352,7 +354,10 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
       backgroundColor = block.getBackground();
     }
     bg.setColor(ColorUtils.parseColor(backgroundColor));
-    button.setBackground(bg);
+
+    Drawable buttonBackground = applyBorder(button, bg, block, backgroundColor);
+
+    button.setBackground(buttonBackground);
 
     if (block.getAction() != null) {
       BannerAction action = block.getAction();
@@ -380,6 +385,48 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     });
 
     body.addView(button);
+  }
+
+  private Drawable applyBorder(Button button, GradientDrawable bg, BannerButtonBlock block, String backgroundColor) {
+    int borderWidth = block.getBorderWidth();
+    if (borderWidth <= 0) {
+      return bg;
+    }
+
+    String borderColor = block.getBorderColor();
+    int strokeColor;
+    if (borderColor != null && !borderColor.isEmpty()) {
+      strokeColor = ColorUtils.parseColor(borderColor);
+    } else {
+      strokeColor = Color.WHITE;
+    }
+
+    int strokeWidthPx = Math.round(borderWidth * getPXScale());
+    float cornerRadius = block.getRadius() * getPXScale();
+
+    String borderStyle = block.getBorderStyle();
+    boolean isDashed = borderStyle != null && borderStyle.equalsIgnoreCase("dashed");
+    boolean isDotted = borderStyle != null && borderStyle.equalsIgnoreCase("dotted");
+
+    if (isDashed || isDotted) {
+      button.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+
+      GradientDrawable borderDrawable = new GradientDrawable();
+      borderDrawable.setShape(GradientDrawable.RECTANGLE);
+      borderDrawable.setColor(Color.TRANSPARENT);
+      borderDrawable.setCornerRadius(cornerRadius);
+      if (isDashed) {
+        borderDrawable.setStroke(strokeWidthPx, strokeColor, strokeWidthPx * 3f, strokeWidthPx * 2f);
+      } else {
+        borderDrawable.setStroke(strokeWidthPx, strokeColor, strokeWidthPx, strokeWidthPx);
+      }
+
+      return new LayerDrawable(new Drawable[] {bg, borderDrawable});
+    }
+
+    // solid (default)
+    bg.setStroke(strokeWidthPx, strokeColor);
+    return bg;
   }
 
   public static Spanned removeTrailingBlankLines(Spanned spanned) {

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/blocks/BannerButtonBlock.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/blocks/BannerButtonBlock.java
@@ -25,6 +25,9 @@ public class BannerButtonBlock extends BannerBlock {
   private List<BannerBlockScreen> blockScreens;
   private String family = null;
   private String id;
+  private int borderWidth;
+  private String borderColor;
+  private String borderStyle;
 
   private BannerButtonBlock() {
   }
@@ -81,6 +84,18 @@ public class BannerButtonBlock extends BannerBlock {
     return id;
   }
 
+  public int getBorderWidth() {
+    return borderWidth;
+  }
+
+  public String getBorderColor() {
+    return borderColor;
+  }
+
+  public String getBorderStyle() {
+    return borderStyle;
+  }
+
   public static BannerButtonBlock createButtonBlock(JSONObject json) throws JSONException {
     BannerButtonBlock buttonBlock = new BannerButtonBlock();
 
@@ -107,6 +122,9 @@ public class BannerButtonBlock extends BannerBlock {
     buttonBlock.radius = json.optInt("radius");
     buttonBlock.action = BannerAction.create(json.getJSONObject("action"));
     buttonBlock.blockScreens = new LinkedList<>();
+    buttonBlock.borderWidth = json.optInt("borderWidth");
+    buttonBlock.borderColor = json.optString("borderColor");
+    buttonBlock.borderStyle = json.optString("borderStyle");
 
     if (json.has("screens")) {
       JSONArray blockArray = json.getJSONArray("screens");

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
@@ -14,6 +14,7 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.LayerDrawable;
+import android.os.Build;
 import android.net.Uri;
 import android.text.Spanned;
 import android.util.Base64;
@@ -42,7 +43,6 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.cleverpush.CleverPush;
 import com.cleverpush.R;
-import com.cleverpush.banner.AppBannerCarouselAdapter;
 import com.cleverpush.banner.AppBannerWebViewClient;
 import com.cleverpush.banner.WebViewActivity;
 import com.cleverpush.banner.models.Banner;
@@ -272,7 +272,7 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
     if (borderColor != null && !borderColor.isEmpty()) {
       strokeColor = ColorUtils.parseColor(borderColor);
     } else {
-      strokeColor = ColorUtils.parseColor(backgroundColor);
+      strokeColor = Color.WHITE;
     }
 
     int strokeWidthPx = Math.round(borderWidth * getPXScale());
@@ -282,7 +282,7 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
     boolean isDashed = borderStyle != null && borderStyle.equalsIgnoreCase("dashed");
     boolean isDotted = borderStyle != null && borderStyle.equalsIgnoreCase("dotted");
 
-    if (isDashed || isDotted) {
+    if ((isDashed || isDotted) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       button.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
 
       GradientDrawable borderDrawable = new GradientDrawable();

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
@@ -11,7 +11,9 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.LayerDrawable;
 import android.net.Uri;
 import android.text.Spanned;
 import android.util.Base64;
@@ -230,7 +232,10 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
       backgroundColor = block.getBackground();
     }
     bg.setColor(ColorUtils.parseColor(backgroundColor));
-    button.setBackground(bg);
+
+    Drawable buttonBackground = applyBorder(button, bg, block, backgroundColor);
+
+    button.setBackground(buttonBackground);
 
     if (block.getAction() != null) {
       button.setOnClickListener(view -> this.onClickListener(block.getAction()));
@@ -254,6 +259,48 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
     });
 
     body.addView(button);
+  }
+
+  private Drawable applyBorder(Button button, GradientDrawable bg, BannerButtonBlock block, String backgroundColor) {
+    int borderWidth = block.getBorderWidth();
+    if (borderWidth <= 0) {
+      return bg;
+    }
+
+    String borderColor = block.getBorderColor();
+    int strokeColor;
+    if (borderColor != null && !borderColor.isEmpty()) {
+      strokeColor = ColorUtils.parseColor(borderColor);
+    } else {
+      strokeColor = ColorUtils.parseColor(backgroundColor);
+    }
+
+    int strokeWidthPx = Math.round(borderWidth * getPXScale());
+    float cornerRadius = block.getRadius() * getPXScale();
+
+    String borderStyle = block.getBorderStyle();
+    boolean isDashed = borderStyle != null && borderStyle.equalsIgnoreCase("dashed");
+    boolean isDotted = borderStyle != null && borderStyle.equalsIgnoreCase("dotted");
+
+    if (isDashed || isDotted) {
+      button.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+
+      GradientDrawable borderDrawable = new GradientDrawable();
+      borderDrawable.setShape(GradientDrawable.RECTANGLE);
+      borderDrawable.setColor(Color.TRANSPARENT);
+      borderDrawable.setCornerRadius(cornerRadius);
+      if (isDashed) {
+        borderDrawable.setStroke(strokeWidthPx, strokeColor, strokeWidthPx * 3f, strokeWidthPx * 2f);
+      } else {
+        borderDrawable.setStroke(strokeWidthPx, strokeColor, strokeWidthPx, strokeWidthPx);
+      }
+
+      return new LayerDrawable(new Drawable[] {bg, borderDrawable});
+    }
+
+    // solid (default)
+    bg.setStroke(strokeWidthPx, strokeColor);
+    return bg;
   }
 
   private void composeTextBlock(LinearLayout body, BannerTextBlock block, int position) {


### PR DESCRIPTION
Add configurable border (width, color, solid/dashed/dotted style) to banner buttons

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering and model parsing; default is no border when width is zero, with no auth or data-path changes.
> 
> **Overview**
> Adds **configurable button borders** for in-app banner and inbox detail carousel buttons, driven by new JSON fields on button blocks.
> 
> `BannerButtonBlock` now reads **`borderWidth`**, **`borderColor`**, and **`borderStyle`** and exposes getters. Button backgrounds go through a new **`applyBorder`** helper in **`AppBannerCarouselAdapter`** and **`InboxDetailBannerCarouselAdapter`**: when width is ≤ 0, behavior stays unchanged (fill only). Otherwise borders use the block’s corner radius and PX scale; **solid** borders use `GradientDrawable.setStroke`, while **dashed** / **dotted** use a stacked `LayerDrawable` and software rendering on API 21+. Missing border color defaults to white.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 480d134d8f55044143e7bba4491c9ab591a43a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable borders to Android in‑app banner buttons: width, color, and solid/dashed/dotted styles. Aligns with Linear CP‑11668 and keeps current look by default.

- **New Features**
  - `BannerButtonBlock`: adds `borderWidth`, `borderColor`, `borderStyle` and parses them from JSON.
  - Button rendering: draws solid/dashed/dotted borders using `GradientDrawable`/`LayerDrawable`, respects corner radius and PX scale; dashed/dotted require Lollipop+ (fallback to solid) and force software layer; no border when width ≤ 0.
  - Applied in `AppBannerCarouselAdapter` and `InboxDetailBannerCarouselAdapter`; default border color is white when `borderColor` is missing.

<sup>Written for commit 480d134d8f55044143e7bba4491c9ab591a43a34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

