### PR TITLE
feature/cp-11495-api-payload-update-android

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -4876,4 +4876,40 @@ public class CleverPush {
     editor.apply();
     this.trySubscriptionSync();
   }
+
+  public void clearAllBannerDeliveryDates() {
+    try {
+      getSharedPreferences(getContext())
+              .edit()
+              .remove(CleverPushPreferences.APP_BANNER_DELIVERY_DATES)
+              .apply();
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "Failed clearing banner delivery dates", e);
+    }
+  }
+
+  public void clearBannerDeliveryDate(String bannerId) {
+    if (bannerId == null || bannerId.isEmpty()) {
+      return;
+    }
+
+    try {
+      SharedPreferences preferences = getSharedPreferences(getContext());
+
+      String data = preferences.getString(CleverPushPreferences.APP_BANNER_DELIVERY_DATES, "{}");
+
+      JSONObject deliveryDates = new JSONObject(data);
+
+      if (deliveryDates.has(bannerId)) {
+        deliveryDates.remove(bannerId);
+
+        preferences.edit()
+                .putString(CleverPushPreferences.APP_BANNER_DELIVERY_DATES, deliveryDates.toString())
+                .apply();
+      }
+
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "Failed clearing banner delivery date for bannerId: " + bannerId, e);
+    }
+  }
 }

--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -49,5 +49,6 @@ public class CleverPushPreferences {
   public static final String APP_BANNER_PER_SESSION = "CleverPush_APP_BANNER_PER_SESSION";
   public static final String INBOX_VIEW_NOTIFICATION_OPENED = "CleverPush_INBOX_VIEW_NOTIFICATION_OPENED";
   public static final String SUBSCRIPTION_PIANO_SEGMENTS = "CleverPush_SUBSCRIPTION_PIANO_SEGMENTS";
+  public static final String APP_BANNER_DELIVERY_DATES = "CleverPush_APP_BANNER_DELIVERY_DATES";
 
 }

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -597,6 +597,10 @@ public class AppBannerModule {
           continue;
         }
 
+        if (!isBannerRelativeToDeliveryAllowed(banner)) {
+          continue;
+        }
+
         if (!isBannerTargetingAllowed(banner)) {
           continue;
         }
@@ -657,6 +661,79 @@ public class AppBannerModule {
     return banner.getStopAtType() != BannerStopAtType.SpecificTime
         || banner.getStopAt() == null
         || banner.getStopAt().after(now);
+  }
+
+  boolean isBannerRelativeToDeliveryAllowed(Banner banner) {
+    if (banner == null) {
+      return false;
+    }
+
+    if (banner.getStopAtType() != BannerStopAtType.RelativeToDelivery
+            || banner.getStopAtRelativeDays() <= 0) {
+      return true;
+    }
+
+    Long deliveryDate = getBannerDeliveryDate(banner);
+    if (deliveryDate == null) {
+      return true;
+    }
+
+    long expiresAt = deliveryDate + TimeUnit.DAYS.toMillis(banner.getStopAtRelativeDays());
+    return System.currentTimeMillis() < expiresAt;
+  }
+
+  private void saveBannerDeliveryDate(Banner banner) {
+    if (banner == null
+            || banner.getStopAtType() != BannerStopAtType.RelativeToDelivery
+            || banner.getStopAtRelativeDays() <= 0) {
+      return;
+    }
+
+    try {
+      JSONObject deliveryDates = getBannerDeliveryDates();
+
+      if (!deliveryDates.has(banner.getId())) {
+        deliveryDates.put(banner.getId(), System.currentTimeMillis());
+
+        sharedPreferences.edit()
+                .putString(CleverPushPreferences.APP_BANNER_DELIVERY_DATES, deliveryDates.toString())
+                .apply();
+      }
+
+    } catch (Exception e) {
+      Logger.e(TAG, "Failed saving banner delivery date", e);
+    }
+  }
+
+  private Long getBannerDeliveryDate(Banner banner) {
+    if (banner == null) {
+      return null;
+    }
+
+    try {
+      JSONObject deliveryDates = getBannerDeliveryDates();
+
+      if (!deliveryDates.has(banner.getId())) {
+        return null;
+      }
+
+      return deliveryDates.getLong(banner.getId());
+
+    } catch (Exception e) {
+      Logger.e(TAG, "getBannerDeliveryDate: Failed reading banner delivery date", e);
+      return null;
+    }
+  }
+
+  private JSONObject getBannerDeliveryDates() {
+    try {
+      String data = sharedPreferences.getString(CleverPushPreferences.APP_BANNER_DELIVERY_DATES, "{}");
+
+      return new JSONObject(data);
+
+    } catch (Exception e) {
+      return new JSONObject();
+    }
   }
 
   boolean isBannerTargetingAllowed(Banner banner) {
@@ -1988,6 +2065,11 @@ public class AppBannerModule {
           return;
         }
 
+        if (!isBannerRelativeToDeliveryAllowed(banner)) {
+          Logger.d(TAG, "Skipping Banner " + banner.getId() + " because: RelativeToDelivery " + banner.getStopAtRelativeDays() + " days");
+          return;
+        }
+
         if (!isBannerTargetingAllowed(banner)) {
           Logger.d(TAG, "Skipping Banner " + banner.getId() + " because: Targeting not allowed");
           return;
@@ -2160,6 +2242,8 @@ public class AppBannerModule {
     if (getCurrentActivity() == null) {
       return;
     }
+
+    saveBannerDeliveryDate(banner);
 
     SharedPreferences sharedPreferences =
         getCurrentActivity().getSharedPreferences(APP_BANNER_SHARED_PREFS, Context.MODE_PRIVATE);

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -2239,11 +2239,11 @@ public class AppBannerModule {
   }
 
   void setBannerIsShown(Banner banner) {
+    saveBannerDeliveryDate(banner);
+
     if (getCurrentActivity() == null) {
       return;
     }
-
-    saveBannerDeliveryDate(banner);
 
     SharedPreferences sharedPreferences =
         getCurrentActivity().getSharedPreferences(APP_BANNER_SHARED_PREFS, Context.MODE_PRIVATE);

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/Banner.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/Banner.java
@@ -74,6 +74,7 @@ public class Banner {
   private int everyXDays;
   private BannerAttributesLogicType attributesLogic = BannerAttributesLogicType.And;
   private List<BannerOSTarget> osTarget;
+  private int stopAtRelativeDays;
 
   private Banner() {
   }
@@ -300,6 +301,10 @@ public class Banner {
 
   public BannerAttributesLogicType getAttributesLogic() {
     return attributesLogic;
+  }
+
+  public int getStopAtRelativeDays() {
+    return stopAtRelativeDays;
   }
 
   public List<BannerOSTarget> getOsTarget() {
@@ -539,6 +544,7 @@ public class Banner {
       }
     }
 
+    banner.stopAtRelativeDays = json.optInt("stopAtRelativeDays");
     return banner;
   }
 

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/BannerStopAtType.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/BannerStopAtType.java
@@ -5,13 +5,15 @@ import java.util.Map;
 
 public enum BannerStopAtType {
   Forever,
-  SpecificTime;
+  SpecificTime,
+  RelativeToDelivery;
 
   private static final Map<String, BannerStopAtType> mapStopAtType = new HashMap<>();
 
   static {
     mapStopAtType.put("forever", BannerStopAtType.Forever);
     mapStopAtType.put("specific_time", BannerStopAtType.SpecificTime);
+    mapStopAtType.put("relative_to_delivery", BannerStopAtType.RelativeToDelivery);
   }
 
   public static BannerStopAtType fromString(String raw) {


### PR DESCRIPTION
Adds support for RelativeToDelivery expiration for app banners and introduces clearAllBannerDeliveryDates() and clearBannerDeliveryDate(String bannerId) to clear stored delivery data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which banners are eligible to display and adds durable SharedPreferences state; mistakes could hide banners early or show them too long, but scope is limited to app banner targeting.
> 
> **Overview**
> Adds **RelativeToDelivery** as a banner stop type (`relative_to_delivery` / `stopAtRelativeDays` from the API), so banners can expire a fixed number of days after they are first **shown**, not only at a fixed calendar time.
> 
> On first display, the SDK records a per-banner delivery timestamp in SharedPreferences (`APP_BANNER_DELIVERY_DATES`). Group listing and the show pipeline now skip banners past that window via `isBannerRelativeToDeliveryAllowed`. **`CleverPush.clearAllBannerDeliveryDates()`** and **`clearBannerDeliveryDate(bannerId)`** let apps reset that stored state (e.g. after config or testing changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae2a535b44e84702306d3eb84fca6cdbcd9c3a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->