### PR TITLE
hotfix/cp-11915-missing-proguard-rule-for-notificationserviceextension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
     ext {
         buildVersions = [
-                compileSdkVersion: 33,
+                compileSdkVersion: 34,
         ]
         androidGradlePluginVersion = '8.1.4'
         googleServicesGradlePluginVersion = '4.3.3'
         huaweiAgconnectVersion = '1.2.1.301'
         huaweiHmsPushVersion = '4.0.3.301'
-        kotlinVersion = '1.5.20'
+        kotlinVersion = '1.9.22'
         jacocoVersion = '0.8.10'
     }
 

--- a/cleverpush-example/build.gradle
+++ b/cleverpush-example/build.gradle
@@ -1,10 +1,11 @@
 plugins {
     id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {
     namespace 'com.cleverpush.cleverpush_example_android'
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "com.cleverpush.cleverpush_example_android"
@@ -15,12 +16,12 @@ android {
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-       /* //add this options
-        javaCompileOptions {
-            annotationProcessorOptions {
-                includeCompileClasspath = true
-            }
-        }*/
+        /* //add this options
+         javaCompileOptions {
+             annotationProcessorOptions {
+                 includeCompileClasspath = true
+             }
+         }*/
     }
 
     buildTypes {

--- a/cleverpush/build.gradle
+++ b/cleverpush/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     // Google & Firebase
     implementation 'com.google.android.gms:play-services-base:[10.2.1, 18.0.99]'
     implementation 'com.google.android.gms:play-services-location:[16.0.0, 21.0.99]'
-    api 'com.google.firebase:firebase-messaging:[10.2.1, 26.0.0)'
+    api 'com.google.firebase:firebase-messaging:[10.2.1, 25.0.99]'
 
     // Huawei
     compileOnly "com.huawei.hms:push:$huaweiHmsPushVersion"

--- a/cleverpush/consumer-proguard-rules.pro
+++ b/cleverpush/consumer-proguard-rules.pro
@@ -1,6 +1,9 @@
 -keep class com.cleverpush.** { *; }
 -dontwarn com.cleverpush.**
 
+# NotificationServiceExtension
+-keep class * implements com.cleverpush.NotificationServiceExtension { *; }
+
 # Firebase
 -keep class com.google.firebase.messaging.FirebaseMessaging { *; }
 -keep class com.google.firebase.iid.FirebaseInstanceId { *; }

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
@@ -20,6 +20,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.concurrent.ExecutionException;
 
 public class SubscriptionManagerFCM extends SubscriptionManagerBase {
 
@@ -44,6 +45,12 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
 
     try {
       return getTokenWithClassFirebaseMessaging();
+    } catch (ExecutionException | InterruptedException e) {
+      if (isServiceNotAvailable(e)) {
+        throw new IOException(ERROR_SERVICE_NOT_AVAILABLE);
+      }
+      Logger.e(LOG_TAG, "FirebaseMessaging.getToken() failed", e);
+      return null;
     } catch (Exception e) {
       Logger.e(LOG_TAG, "FirebaseMessaging.getToken not found, attempting to use FirebaseInstanceId.getToken", e);
     }
@@ -59,6 +66,17 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
     }
 
     return null;
+  }
+
+  private boolean isServiceNotAvailable(Throwable throwable) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (ERROR_SERVICE_NOT_AVAILABLE.equals(current.getMessage())) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 
   private void initFirebaseApp(String senderId) {

--- a/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
+++ b/cleverpush/src/main/java/com/cleverpush/manager/SubscriptionManagerFCM.java
@@ -45,7 +45,11 @@ public class SubscriptionManagerFCM extends SubscriptionManagerBase {
 
     try {
       return getTokenWithClassFirebaseMessaging();
-    } catch (ExecutionException | InterruptedException e) {
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      Logger.e(LOG_TAG, "FirebaseMessaging.getToken() interrupted", e);
+      return null;
+    } catch (ExecutionException e) {
       if (isServiceNotAvailable(e)) {
         throw new IOException(ERROR_SERVICE_NOT_AVAILABLE);
       }


### PR DESCRIPTION
Added a Proguard rule for `NotificationServiceExtension`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect push token registration and release shrinker behavior for notification extensions; build dependency caps could affect apps pinning newer Firebase Messaging.
> 
> **Overview**
> **Release notification extensions** by adding a consumer ProGuard rule that keeps any class implementing `NotificationServiceExtension`, so minified app builds no longer strip customer extension classes and break notification handling (CP-11915).
> 
> **FCM registration** in `SubscriptionManagerFCM` now treats `FirebaseMessaging.getToken()` failures explicitly: restores interrupt on `InterruptedException`, maps nested `SERVICE_NOT_AVAILABLE` from `ExecutionException` to the existing retry path via `IOException`, and logs other execution failures before falling back to `FirebaseInstanceId`.
> 
> **Build/tooling**: root and example `compileSdkVersion` **34**, Kotlin **1.9.22**, Kotlin Android plugin on the example app, and `firebase-messaging` dependency upper bound tightened to **25.0.99**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643e3f70f88a7d5cf87c40484062ec6dda8407ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a consumer ProGuard rule to keep `NotificationServiceExtension`, fixing release builds where the extension was stripped and notifications failed. Also hardens FCM token handling. Addresses Linear CP-11915.

- **Bug Fixes**
  - Keep any class implementing `com.cleverpush.NotificationServiceExtension` in consumer ProGuard rules.
  - In `SubscriptionManagerFCM`, handle `InterruptedException` (preserve interrupt) and `ExecutionException` from `FirebaseMessaging.getToken()`; map nested "SERVICE_NOT_AVAILABLE" to `IOException` and log others.

- **Dependencies**
  - Cap `com.google.firebase:firebase-messaging` to `[10.2.1, 25.0.99]`.
  - Set `compileSdkVersion` to 34 and Kotlin to 1.9.22; apply `org.jetbrains.kotlin.android` in the example app.

<sup>Written for commit 643e3f70f88a7d5cf87c40484062ec6dda8407ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

