### PR TITLE
feature/cp-11480-app-push-listen-to-beacons-and-trigger-an-event-android

### DIFF
--- a/cleverpush/src/main/AndroidManifest.xml
+++ b/cleverpush/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.cleverpush">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -104,4 +105,15 @@
     <uses-permission android:name="me.everything.badger.permission.BADGE_COUNT_WRITE" />
 
     <!-- End: ShortcutBadger -->
+
+    <!-- START: Beacons / BLE monitoring -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-feature
+        android:name="android.hardware.bluetooth_le"
+        android:required="false" />
+    <!-- End: Beacons / BLE monitoring -->
 </manifest>

--- a/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
+++ b/cleverpush/src/main/java/com/cleverpush/ActivityLifecycleListener.java
@@ -198,6 +198,9 @@ public class ActivityLifecycleListener implements Application.ActivityLifecycleC
     if (activity == null) {
       return false;
     }
+    if (activity instanceof PermissionActivity) {
+      return false;
+    }
     if (activity instanceof NotificationOpenedActivity) {
       try {
         if (!CleverPush.getInstance(CleverPush.context).isUsingNotificationOpenedCallbackListener()) {

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -41,6 +41,8 @@ import androidx.core.content.ContextCompat;
 import androidx.lifecycle.Observer;
 
 import com.cleverpush.banner.AppBannerModule;
+import com.cleverpush.beacon.BeaconConfig;
+import com.cleverpush.beacon.BeaconManager;
 import com.cleverpush.database.DatabaseClient;
 import com.cleverpush.database.TableBannerTrackEvent;
 import com.cleverpush.listener.ActivityInitializedListener;
@@ -48,6 +50,7 @@ import com.cleverpush.listener.AppBannerClosedListener;
 import com.cleverpush.listener.AppBannerOpenedListener;
 import com.cleverpush.listener.AppBannerShownListener;
 import com.cleverpush.listener.AppBannersListener;
+import com.cleverpush.listener.BeaconDetectedListener;
 import com.cleverpush.listener.ChannelAttributesListener;
 import com.cleverpush.listener.ChannelConfigListener;
 import com.cleverpush.listener.ChannelTagsListener;
@@ -227,6 +230,7 @@ public class CleverPush {
   public static BroadcastReceiver broadcastReceiverHandler = new BroadcastReceiverHandler();
   private PendingIntent geofencePendingIntent;
   private GeofencingClient geofencingClient;
+  private BeaconDetectedListener pendingBeaconDetectedListener;
   private String authorizerToken;
   private boolean isSubscriptionChanged = false;
   private IabTcfMode iabTcfMode = null;
@@ -1335,6 +1339,174 @@ public class CleverPush {
         Logger.d(LOG_TAG, "GoogleApiClient onConnectionSuspended");
       }
     };
+  }
+
+  public void onBeaconDetected(BeaconDetectedListener listener) {
+    this.pendingBeaconDetectedListener = listener;
+    try {
+      BeaconManager.getInstance(getContext()).setBeaconDetectedListener(listener);
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "Error setting beacon detected listener.", t);
+    }
+  }
+
+  /**
+   * Enables debug beacon scanning to log all BLE advertisements.
+   * For diagnostics only; disable in production. Call before {@link #initBeacons()}.
+   */
+  public void setBeaconDebugScanAll(boolean enabled) {
+    try {
+      BeaconManager.getInstance(getContext()).setDebugScanAllBeacons(enabled);
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "Error setting beacon debug scan mode.", t);
+    }
+  }
+
+  /**
+   * Optional: sets how many minutes to wait before the same beacon
+   * can trigger again in the same app session.
+   *
+   * @param intervalMinutes wait time in minutes (0 = every detection)
+   */
+  public void setBeaconEventInterval(long intervalMinutes) {
+    try {
+      long intervalMs = intervalMinutes <= 0 ? 0L : intervalMinutes * 60_000L;
+      BeaconManager.getInstance(getContext()).setCooldownMs(intervalMs);
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "Error setting beacon event interval.", t);
+    }
+  }
+
+  /**
+   * Starts beacon monitoring and automatically handles
+   * setup, permissions, and scanning configuration.
+   */
+  public void initBeacons() {
+    initBeacons(getCurrentActivity());
+  }
+
+  public void initBeacons(Activity dialogActivity) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+      Logger.w(LOG_TAG, "initBeacons: BLE scanning requires Android 5.0 (API 21) or higher.");
+      return;
+    }
+
+    BeaconManager beaconManager = BeaconManager.getInstance(getContext());
+    if (this.pendingBeaconDetectedListener != null) {
+      beaconManager.setBeaconDetectedListener(this.pendingBeaconDetectedListener);
+    }
+
+    if (!beaconManager.isBleSupported()) {
+      Logger.w(LOG_TAG, "initBeacons: This device does not support Bluetooth Low Energy.");
+      return;
+    }
+
+    if (hasBeaconPermissions()) {
+      startBeaconMonitoring();
+      return;
+    }
+
+    if (dialogActivity == null) {
+      getActivityLifecycleListener().setActivityInitializedListener(() -> initBeacons(getCurrentActivity()));
+      return;
+    }
+
+    requestBeaconPermissions(dialogActivity);
+  }
+
+  private void startBeaconMonitoring() {
+    getChannelConfig(config -> {
+      try {
+        List<BeaconConfig> beacons = BeaconConfig.listFromConfig(config);
+        if (beacons.isEmpty()) {
+          Logger.d(LOG_TAG, "initBeacons: no beacons configured for this channel.");
+          return;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+          BeaconManager.getInstance(getContext()).start(beacons);
+        }
+      } catch (Throwable t) {
+        Logger.e(LOG_TAG, "Error starting beacon monitoring.", t);
+      }
+    });
+  }
+
+  public String[] getRequiredBeaconPermissions() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      // ACCESS_FINE_LOCATION is required in addition to the Bluetooth permissions: beacon
+      // advertisements are on Android's BLE location denylist and are only delivered to scanners
+      // that hold location permission (we do not use neverForLocation).
+      return new String[] {
+          "android.permission.BLUETOOTH_SCAN",
+          "android.permission.BLUETOOTH_CONNECT",
+          Manifest.permission.ACCESS_FINE_LOCATION
+      };
+    }
+    return new String[] {Manifest.permission.ACCESS_FINE_LOCATION};
+  }
+
+  public boolean hasBeaconPermissions() {
+    for (String permission : getRequiredBeaconPermissions()) {
+      if (ContextCompat.checkSelfPermission(getContext(), permission) != PackageManager.PERMISSION_GRANTED) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void requestBeaconPermissions(Activity dialogActivity) {
+    String[] missing = getMissingBeaconPermissions();
+    if (missing.length == 0) {
+      startBeaconMonitoring();
+      return;
+    }
+    requestPermissions(dialogActivity, missing, new PermissionActivity.PermissionCallback() {
+      @Override
+      public void onGrant() {
+        Logger.d(LOG_TAG, "initBeacons: beacon permissions granted.");
+        startBeaconMonitoring();
+      }
+
+      @Override
+      public void onDeny() {
+        Logger.d(LOG_TAG, "initBeacons: beacon permissions denied by user. Monitoring not started. "
+            + "Call initBeacons() again to retry (e.g. after explaining why it is needed).");
+      }
+    });
+  }
+
+  private String[] getMissingBeaconPermissions() {
+    List<String> missing = new ArrayList<>();
+    for (String permission : getRequiredBeaconPermissions()) {
+      if (ContextCompat.checkSelfPermission(getContext(), permission) != PackageManager.PERMISSION_GRANTED) {
+        missing.add(permission);
+      }
+    }
+    return missing.toArray(new String[0]);
+  }
+
+  private void requestPermissions(Activity dialogActivity, String[] permissionTypes,
+                                  PermissionActivity.PermissionCallback callback) {
+    try {
+      if (dialogActivity == null || dialogActivity.getClass().equals(PermissionActivity.class)) {
+        return;
+      }
+      if (permissionTypes == null || permissionTypes.length == 0) {
+        return;
+      }
+
+      Logger.d(LOG_TAG, "Requesting permissions: " + Arrays.toString(permissionTypes));
+
+      PermissionActivity.registerAsCallback(PermissionActivity.keyFor(permissionTypes), callback);
+
+      Intent intent = new Intent(dialogActivity, PermissionActivity.class);
+      intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+      intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+      intent.putExtra(PermissionActivity.INTENT_EXTRA_PERMISSION_TYPES, permissionTypes);
+      dialogActivity.startActivity(intent);
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "Exception during multi-permission request.", e);
+    }
   }
 
   public void trackPageView(String url) {

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -1406,7 +1406,8 @@ public class CleverPush {
       return;
     }
 
-    if (dialogActivity == null) {
+    if (dialogActivity == null || dialogActivity instanceof PermissionActivity) {
+      Logger.d(LOG_TAG, "initBeacons: no usable host activity yet, deferring until an Activity is resumed.");
       getActivityLifecycleListener().setActivityInitializedListener(() -> initBeacons(getCurrentActivity()));
       return;
     }

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -231,6 +231,7 @@ public class CleverPush {
   private PendingIntent geofencePendingIntent;
   private GeofencingClient geofencingClient;
   private BeaconDetectedListener pendingBeaconDetectedListener;
+  private boolean beaconInitDeferred = false;
   private String authorizerToken;
   private boolean isSubscriptionChanged = false;
   private IabTcfMode iabTcfMode = null;
@@ -1406,9 +1407,16 @@ public class CleverPush {
       return;
     }
 
-    if (dialogActivity == null || dialogActivity instanceof PermissionActivity) {
+    if (!ActivityLifecycleListener.isValidHostActivity(dialogActivity)) {
+      if (beaconInitDeferred) {
+        return;
+      }
+      beaconInitDeferred = true;
       Logger.d(LOG_TAG, "initBeacons: no usable host activity yet, deferring until an Activity is resumed.");
-      getActivityLifecycleListener().setActivityInitializedListener(() -> initBeacons(getCurrentActivity()));
+      getActivityLifecycleListener().setActivityInitializedListener(() -> {
+        beaconInitDeferred = false;
+        initBeacons(getCurrentActivity());
+      });
       return;
     }
 

--- a/cleverpush/src/main/java/com/cleverpush/PermissionActivity.java
+++ b/cleverpush/src/main/java/com/cleverpush/PermissionActivity.java
@@ -2,7 +2,6 @@ package com.cleverpush;
 
 import static com.cleverpush.Constants.LOG_TAG;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -24,18 +23,24 @@ public class PermissionActivity extends Activity implements ActivityCompat.OnReq
   }
 
   public static final String INTENT_EXTRA_PERMISSION_TYPE = "PERMISSION_TYPE";
+  public static final String INTENT_EXTRA_PERMISSION_TYPES = "PERMISSION_TYPES";
   private static final int PERMISSION_REQUEST_CODE = 100;
   private static final String TAG = PermissionActivity.class.getCanonicalName();
 
   private static final HashMap<String, PermissionCallback> callbackMap = new HashMap<>();
 
-  private String permissionType;
+  private String[] permissionTypes;
+  private String callbackKey;
 
   public static void registerAsCallback(
       @NonNull String permissionType,
       @NonNull PermissionCallback callback
   ) {
     callbackMap.put(permissionType, callback);
+  }
+
+  public static String keyFor(@NonNull String[] permissionTypes) {
+    return android.text.TextUtils.join(",", permissionTypes);
   }
 
   @Override
@@ -51,28 +56,51 @@ public class PermissionActivity extends Activity implements ActivityCompat.OnReq
   }
 
   private void requestPermission(Bundle extras) {
-    permissionType = extras.getString(INTENT_EXTRA_PERMISSION_TYPE);
-    ActivityCompat.requestPermissions(this, new String[] {permissionType}, PERMISSION_REQUEST_CODE);
+    if (extras == null) {
+      finish();
+      return;
+    }
+    String[] types = extras.getStringArray(INTENT_EXTRA_PERMISSION_TYPES);
+    if (types == null) {
+      String single = extras.getString(INTENT_EXTRA_PERMISSION_TYPE);
+      if (single == null) {
+        finish();
+        return;
+      }
+      types = new String[] {single};
+    }
+    permissionTypes = types;
+    callbackKey = keyFor(types);
+    ActivityCompat.requestPermissions(this, permissionTypes, PERMISSION_REQUEST_CODE);
   }
 
   @Override
   public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     if (requestCode == PERMISSION_REQUEST_CODE) {
-      boolean isGranted = ContextCompat.checkSelfPermission(this, permissionType) == PackageManager.PERMISSION_GRANTED;
+      boolean allGranted = true;
+      for (String permission : permissionTypes) {
+        if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
+          allGranted = false;
+          break;
+        }
+      }
       Logger.d(LOG_TAG, "onRequestPermissionsResult: " + permissions.length + " " + grantResults.length);
 
-      PermissionCallback callback = callbackMap.get(permissionType);
+      PermissionCallback callback = callbackMap.get(callbackKey);
+      if (callback == null && permissionTypes.length == 1) {
+        callback = callbackMap.get(permissionTypes[0]);
+      }
       if (callback == null) {
-        Logger.w(LOG_TAG, "onRequestPermissionsResult: Missing callback for permissionType: " + permissionType);
+        Logger.w(LOG_TAG, "onRequestPermissionsResult: Missing callback for permissionType: " + callbackKey);
         finish();
         return;
       }
 
-      if (isGranted) {
-        Logger.d(LOG_TAG, "Permission granted: " + permissionType);
+      if (allGranted) {
+        Logger.d(LOG_TAG, "Permission granted: " + callbackKey);
         callback.onGrant();
       } else {
-        Logger.d(LOG_TAG, "Permission denied: " + permissionType);
+        Logger.d(LOG_TAG, "Permission denied: " + callbackKey);
         callback.onDeny();
       }
     }

--- a/cleverpush/src/main/java/com/cleverpush/beacon/BeaconConfig.java
+++ b/cleverpush/src/main/java/com/cleverpush/beacon/BeaconConfig.java
@@ -33,6 +33,9 @@ public class BeaconConfig {
       return null;
     }
     String uuid = json.optString("uuid", null);
+    if (uuid != null) {
+      uuid = uuid.trim();
+    }
     if (uuid == null || uuid.isEmpty()) {
       return null;
     }

--- a/cleverpush/src/main/java/com/cleverpush/beacon/BeaconConfig.java
+++ b/cleverpush/src/main/java/com/cleverpush/beacon/BeaconConfig.java
@@ -1,0 +1,107 @@
+package com.cleverpush.beacon;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BeaconConfig {
+
+  private final String id;
+  private final String name;
+  private final String channelId;
+  private final String eventName;
+  private final String uuid;
+  private final String major;
+  private final String minor;
+  private final String storeId;
+
+  public BeaconConfig(String id, String name, String channelId, String eventName, String uuid,
+                      String major, String minor, String storeId) {
+    this.id = id;
+    this.name = name;
+    this.channelId = channelId;
+    this.eventName = eventName;
+    this.uuid = uuid == null ? null : uuid.trim().toLowerCase();
+    this.major = major;
+    this.minor = minor;
+    this.storeId = storeId;
+  }
+
+  public static BeaconConfig fromJson(JSONObject json) {
+    if (json == null) {
+      return null;
+    }
+    String uuid = json.optString("uuid", null);
+    if (uuid == null || uuid.isEmpty()) {
+      return null;
+    }
+    return new BeaconConfig(
+            json.optString("_id", null),
+            json.optString("name", null),
+            json.optString("channel", null),
+            json.optString("eventName", null),
+            uuid,
+            json.optString("major", null),
+            json.optString("minor", null),
+            json.optString("storeId", null)
+    );
+  }
+
+  public static List<BeaconConfig> listFromConfig(JSONObject channelConfig) {
+    List<BeaconConfig> result = new ArrayList<>();
+    if (channelConfig == null) {
+      return result;
+    }
+    org.json.JSONArray array = channelConfig.optJSONArray("beacons");
+    if (array == null) {
+      return result;
+    }
+    for (int i = 0; i < array.length(); i++) {
+      JSONObject item = array.optJSONObject(i);
+      BeaconConfig config = fromJson(item);
+      if (config != null && config.getEventName() != null && !config.getEventName().isEmpty()) {
+        result.add(config);
+      }
+    }
+    return result;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getChannelId() {
+    return channelId;
+  }
+
+  public String getEventName() {
+    return eventName;
+  }
+
+  public String getUuid() {
+    return uuid;
+  }
+
+  public String getMajor() {
+    return major;
+  }
+
+  public String getMinor() {
+    return minor;
+  }
+
+  public String getStoreId() {
+    return storeId;
+  }
+
+  @Override
+  public String toString() {
+    return "BeaconConfig{name='" + name + "', eventName='" + eventName + "', uuid='" + uuid
+            + "', storeId='" + storeId + "'}";
+  }
+}

--- a/cleverpush/src/main/java/com/cleverpush/beacon/BeaconManager.java
+++ b/cleverpush/src/main/java/com/cleverpush/beacon/BeaconManager.java
@@ -99,6 +99,7 @@ public class BeaconManager {
   public void setCooldownMs(long cooldownMs) {
     if (cooldownMs >= 0) {
       this.cooldownMs = cooldownMs;
+      lastTriggeredAt.clear();
     }
   }
 
@@ -131,6 +132,9 @@ public class BeaconManager {
 
       if (configBeacons.isEmpty()) {
         Logger.d(LOG_TAG, "BeaconManager: no beacons configured in channel config, skipping start.");
+        if (started) {
+          stop();
+        }
         return;
       }
 
@@ -170,6 +174,7 @@ public class BeaconManager {
     started = false;
     handler.removeCallbacksAndMessages(null);
     stopScanInternal();
+    lastTriggeredAt.clear();
     Logger.d(LOG_TAG, "BeaconManager: stopped monitoring.");
   }
 
@@ -531,7 +536,7 @@ public class BeaconManager {
   @SuppressWarnings("MissingPermission")
   private void onEnterForeground() {
     foreground = true;
-    if (retriggerOnForeground) {
+    if (retriggerOnForeground && cooldownMs == FIRE_ONCE_COOLDOWN_MS) {
       lastTriggeredAt.clear();
     }
     if (!isStarted()) {

--- a/cleverpush/src/main/java/com/cleverpush/beacon/BeaconManager.java
+++ b/cleverpush/src/main/java/com/cleverpush/beacon/BeaconManager.java
@@ -13,7 +13,10 @@ import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanRecord;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.location.LocationManager;
 import android.os.Build;
@@ -65,6 +68,9 @@ public class BeaconManager {
   private boolean debugScanAllBeacons = false;
   private boolean foregroundTransitionState = false;
   private boolean retriggerOnForeground = true;
+  private boolean monitoringRequested = false;
+  private boolean bluetoothReceiverRegistered = false;
+  private BroadcastReceiver bluetoothStateReceiver;
 
   private BeaconManager(Context context) {
     this.appContext = context.getApplicationContext();
@@ -143,39 +149,115 @@ public class BeaconManager {
         return;
       }
 
-      BluetoothAdapter adapter = getBluetoothAdapter();
-      if (adapter == null || !adapter.isEnabled()) {
-        Logger.w(LOG_TAG, "BeaconManager: Bluetooth is disabled. Monitoring will start once it is enabled and start() is called again.");
-        return;
-      }
-
-      scanner = adapter.getBluetoothLeScanner();
-      if (scanner == null) {
-        Logger.w(LOG_TAG, "BeaconManager: BluetoothLeScanner unavailable.");
-        return;
-      }
-
+      monitoringRequested = true;
       registerLifecycleCallbacks();
+      registerBluetoothStateReceiver();
 
-      if (isStarted()) {
-        Logger.d(LOG_TAG, "BeaconManager: already started, refreshed " + configBeacons.size() + " beacon(s).");
-        return;
-      }
-
-      started = true;
-      Logger.d(LOG_TAG, "BeaconManager: started monitoring " + configBeacons.size() + " beacon(s).");
-      scheduleScanCycle(0);
+      beginScanningIfPossible();
     } catch (Throwable t) {
       Logger.e(LOG_TAG, "BeaconManager: error during start.", t);
     }
   }
 
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private synchronized void beginScanningIfPossible() {
+    if (!monitoringRequested || configBeacons.isEmpty()) {
+      return;
+    }
+
+    BluetoothAdapter adapter = getBluetoothAdapter();
+    if (adapter == null || !adapter.isEnabled()) {
+      Logger.w(LOG_TAG, "BeaconManager: Bluetooth is disabled. Monitoring will start automatically once Bluetooth is enabled.");
+      return;
+    }
+
+    scanner = adapter.getBluetoothLeScanner();
+    if (scanner == null) {
+      Logger.w(LOG_TAG, "BeaconManager: BluetoothLeScanner unavailable.");
+      return;
+    }
+
+    if (isStarted()) {
+      Logger.d(LOG_TAG, "BeaconManager: already started, refreshed " + configBeacons.size() + " beacon(s).");
+      return;
+    }
+
+    started = true;
+    Logger.d(LOG_TAG, "BeaconManager: started monitoring " + configBeacons.size() + " beacon(s).");
+    scheduleScanCycle(0);
+  }
+
   public synchronized void stop() {
+    started = false;
+    monitoringRequested = false;
+    handler.removeCallbacksAndMessages(null);
+    stopScanInternal();
+    unregisterBluetoothStateReceiver();
+    lastTriggeredAt.clear();
+    Logger.d(LOG_TAG, "BeaconManager: stopped monitoring.");
+  }
+
+  private void registerBluetoothStateReceiver() {
+    if (bluetoothReceiverRegistered) {
+      return;
+    }
+    try {
+      bluetoothStateReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+          if (intent == null || !BluetoothAdapter.ACTION_STATE_CHANGED.equals(intent.getAction())) {
+            return;
+          }
+          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
+          }
+          int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR);
+          if (state == BluetoothAdapter.STATE_ON) {
+            onBluetoothTurnedOn();
+          } else if (state == BluetoothAdapter.STATE_OFF || state == BluetoothAdapter.STATE_TURNING_OFF) {
+            onBluetoothTurnedOff();
+          }
+        }
+      };
+      IntentFilter filter = new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED);
+      appContext.registerReceiver(bluetoothStateReceiver, filter);
+      bluetoothReceiverRegistered = true;
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: failed to register Bluetooth state receiver.", t);
+    }
+  }
+
+  private void unregisterBluetoothStateReceiver() {
+    if (!bluetoothReceiverRegistered) {
+      return;
+    }
+    try {
+      appContext.unregisterReceiver(bluetoothStateReceiver);
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: failed to unregister Bluetooth state receiver.", t);
+    } finally {
+      bluetoothReceiverRegistered = false;
+      bluetoothStateReceiver = null;
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private synchronized void onBluetoothTurnedOn() {
+    if (!monitoringRequested || isStarted()) {
+      return;
+    }
+    Logger.d(LOG_TAG, "BeaconManager: Bluetooth enabled - resuming beacon monitoring.");
+    beginScanningIfPossible();
+  }
+
+  private synchronized void onBluetoothTurnedOff() {
+    if (!isStarted()) {
+      return;
+    }
+    Logger.d(LOG_TAG, "BeaconManager: Bluetooth disabled - pausing beacon scanning until it is re-enabled.");
     started = false;
     handler.removeCallbacksAndMessages(null);
     stopScanInternal();
-    lastTriggeredAt.clear();
-    Logger.d(LOG_TAG, "BeaconManager: stopped monitoring.");
   }
 
   private void scheduleScanCycle(long delayMs) {
@@ -239,8 +321,10 @@ public class BeaconManager {
       ScanSettings settings = buildScanSettings();
       scanner.startScan(filters, settings, scanCallback);
       scanning = true;
-      Logger.d(LOG_TAG, "BeaconManager: scan window started (foreground=" + foreground
-              + ", filters=" + (filters == null ? "none/all" : String.valueOf(filters.size())) + ").");
+      if (debugScanAllBeacons) {
+        Logger.d(LOG_TAG, "BeaconManager: scan window started (foreground=" + foreground
+                + ", filters=" + (filters == null ? "none/all" : String.valueOf(filters.size())) + ").");
+      }
     } catch (Throwable t) {
       Logger.e(LOG_TAG, "BeaconManager: failed to start scan.", t);
     }

--- a/cleverpush/src/main/java/com/cleverpush/beacon/BeaconManager.java
+++ b/cleverpush/src/main/java/com/cleverpush/beacon/BeaconManager.java
@@ -138,7 +138,7 @@ public class BeaconManager {
 
       if (configBeacons.isEmpty()) {
         Logger.d(LOG_TAG, "BeaconManager: no beacons configured in channel config, skipping start.");
-        if (started) {
+        if (started || monitoringRequested) {
           stop();
         }
         return;
@@ -620,7 +620,7 @@ public class BeaconManager {
   @SuppressWarnings("MissingPermission")
   private void onEnterForeground() {
     foreground = true;
-    if (retriggerOnForeground && cooldownMs == FIRE_ONCE_COOLDOWN_MS) {
+    if (retriggerOnForeground) {
       lastTriggeredAt.clear();
     }
     if (!isStarted()) {

--- a/cleverpush/src/main/java/com/cleverpush/beacon/BeaconManager.java
+++ b/cleverpush/src/main/java/com/cleverpush/beacon/BeaconManager.java
@@ -1,0 +1,691 @@
+package com.cleverpush.beacon;
+
+import static com.cleverpush.Constants.LOG_TAG;
+
+import android.app.Activity;
+import android.app.ActivityManager;
+import android.app.Application;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanRecord;
+import android.bluetooth.le.ScanResult;
+import android.bluetooth.le.ScanSettings;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.LocationManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.ParcelUuid;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.core.content.ContextCompat;
+
+import com.cleverpush.CleverPush;
+import com.cleverpush.listener.BeaconDetectedListener;
+import com.cleverpush.util.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class BeaconManager {
+
+  private static final long SCAN_WINDOW_MS = 12_000L;
+  private static final long FOREGROUND_IDLE_MS = 60_000L;
+  private static final long BACKGROUND_IDLE_MS = 5 * 60_000L;
+
+  private static final long FIRE_ONCE_COOLDOWN_MS = Long.MAX_VALUE;
+
+  private static volatile BeaconManager instance;
+
+  private final Context appContext;
+  private final Handler handler = new Handler(Looper.getMainLooper());
+
+  private final List<BeaconConfig> configBeacons = new ArrayList<>();
+  private final Map<String, Long> lastTriggeredAt = new ConcurrentHashMap<>();
+
+  private volatile BeaconDetectedListener listener;
+  private long cooldownMs = FIRE_ONCE_COOLDOWN_MS;
+
+  private BluetoothLeScanner scanner;
+  private ScanCallback scanCallback;
+
+  private boolean started = false;
+  private boolean scanning = false;
+  private boolean foreground = true;
+  private boolean lifecycleRegistered = false;
+  private boolean debugScanAllBeacons = false;
+  private boolean foregroundTransitionState = false;
+  private boolean retriggerOnForeground = true;
+
+  private BeaconManager(Context context) {
+    this.appContext = context.getApplicationContext();
+  }
+
+  public static BeaconManager getInstance(Context context) {
+    if (instance == null) {
+      synchronized (BeaconManager.class) {
+        if (instance == null) {
+          instance = new BeaconManager(context);
+        }
+      }
+    }
+    return instance;
+  }
+
+  private static String bytesToHex(byte[] bytes) {
+    if (bytes == null) {
+      return "null";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (byte b : bytes) {
+      sb.append(String.format("%02x", b & 0xFF));
+    }
+    return sb.toString();
+  }
+
+  public void setBeaconDetectedListener(BeaconDetectedListener listener) {
+    this.listener = listener;
+  }
+
+  public void setCooldownMs(long cooldownMs) {
+    if (cooldownMs >= 0) {
+      this.cooldownMs = cooldownMs;
+    }
+  }
+
+  /**
+   * Enables debug BLE scanning for all beacon advertisements.
+   * For diagnostics only; increases battery usage.
+   * Do not enable in production. Call before {@link #start}.
+   */
+  public void setDebugScanAllBeacons(boolean enabled) {
+    this.debugScanAllBeacons = enabled;
+  }
+
+  public boolean isStarted() {
+    return started;
+  }
+
+  /**
+   * Starts beacon monitoring for configured beacons.
+   * Safe to call multiple times; later calls only refresh the beacon list.
+   */
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  public synchronized void start(List<BeaconConfig> beacons) {
+    try {
+      configBeacons.clear();
+      if (beacons != null) {
+        configBeacons.addAll(beacons);
+      }
+
+      logDiagnostics();
+
+      if (configBeacons.isEmpty()) {
+        Logger.d(LOG_TAG, "BeaconManager: no beacons configured in channel config, skipping start.");
+        return;
+      }
+
+      if (!isBleSupported()) {
+        Logger.w(LOG_TAG, "BeaconManager: BLE not supported on this device.");
+        return;
+      }
+
+      BluetoothAdapter adapter = getBluetoothAdapter();
+      if (adapter == null || !adapter.isEnabled()) {
+        Logger.w(LOG_TAG, "BeaconManager: Bluetooth is disabled. Monitoring will start once it is enabled and start() is called again.");
+        return;
+      }
+
+      scanner = adapter.getBluetoothLeScanner();
+      if (scanner == null) {
+        Logger.w(LOG_TAG, "BeaconManager: BluetoothLeScanner unavailable.");
+        return;
+      }
+
+      registerLifecycleCallbacks();
+
+      if (isStarted()) {
+        Logger.d(LOG_TAG, "BeaconManager: already started, refreshed " + configBeacons.size() + " beacon(s).");
+        return;
+      }
+
+      started = true;
+      Logger.d(LOG_TAG, "BeaconManager: started monitoring " + configBeacons.size() + " beacon(s).");
+      scheduleScanCycle(0);
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: error during start.", t);
+    }
+  }
+
+  public synchronized void stop() {
+    started = false;
+    handler.removeCallbacksAndMessages(null);
+    stopScanInternal();
+    Logger.d(LOG_TAG, "BeaconManager: stopped monitoring.");
+  }
+
+  private void scheduleScanCycle(long delayMs) {
+    if (!isStarted()) {
+      return;
+    }
+    handler.postDelayed(this::runScanWindow, delayMs);
+  }
+
+  @SuppressWarnings("MissingPermission")
+  private void runScanWindow() {
+    if (!isStarted()) {
+      return;
+    }
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+      return;
+    }
+
+    foreground = isAppInForeground();
+    try {
+      BluetoothAdapter adapter = getBluetoothAdapter();
+      if (adapter == null || !adapter.isEnabled()) {
+        // Bluetooth turned off mid-session: retry later instead of looping tightly.
+        scheduleScanCycle(currentIdleMs());
+        return;
+      }
+      if (scanner == null) {
+        scanner = adapter.getBluetoothLeScanner();
+      }
+      if (scanner == null) {
+        scheduleScanCycle(currentIdleMs());
+        return;
+      }
+
+      startScanInternal();
+
+      handler.postDelayed(() -> {
+        stopScanInternal();
+        scheduleScanCycle(currentIdleMs());
+      }, currentScanWindowMs());
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: error running scan window.", t);
+      scheduleScanCycle(currentIdleMs());
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @SuppressWarnings("MissingPermission")
+  private void startScanInternal() {
+    if (scanning || scanner == null) {
+      return;
+    }
+    try {
+      if (scanCallback == null) {
+        scanCallback = createScanCallback();
+      }
+      List<ScanFilter> filters = buildScanFilters();
+      if (filters.isEmpty()) {
+        filters = null;
+      }
+      ScanSettings settings = buildScanSettings();
+      scanner.startScan(filters, settings, scanCallback);
+      scanning = true;
+      Logger.d(LOG_TAG, "BeaconManager: scan window started (foreground=" + foreground
+              + ", filters=" + (filters == null ? "none/all" : String.valueOf(filters.size())) + ").");
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: failed to start scan.", t);
+    }
+  }
+
+  @SuppressWarnings("MissingPermission")
+  private void stopScanInternal() {
+    if (!scanning || scanner == null || scanCallback == null) {
+      scanning = false;
+      return;
+    }
+    try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        scanner.stopScan(scanCallback);
+      }
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: failed to stop scan.", t);
+    } finally {
+      scanning = false;
+    }
+  }
+
+  private long currentIdleMs() {
+    if (debugScanAllBeacons) {
+      return 3_000L;
+    }
+    return foreground ? FOREGROUND_IDLE_MS : BACKGROUND_IDLE_MS;
+  }
+
+  private long currentScanWindowMs() {
+    return debugScanAllBeacons ? 9_000L : SCAN_WINDOW_MS;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private ScanSettings buildScanSettings() {
+    int scanMode;
+    if (debugScanAllBeacons) {
+      scanMode = ScanSettings.SCAN_MODE_LOW_LATENCY;
+    } else {
+      scanMode = foreground ? ScanSettings.SCAN_MODE_BALANCED : ScanSettings.SCAN_MODE_LOW_POWER;
+    }
+    ScanSettings.Builder builder = new ScanSettings.Builder().setScanMode(scanMode);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      builder.setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
+              .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+              .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Builds BLE scan filters to limit scanning to relevant beacon advertisements,
+   * improving battery efficiency. Uses hardware filters when possible and
+   * supports debug mode for unfiltered scanning.
+   */
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private List<ScanFilter> buildScanFilters() {
+    List<ScanFilter> filters = new ArrayList<>();
+
+    if (debugScanAllBeacons) {
+      return filters; // empty -> startScanInternal converts to null (unfiltered)
+    }
+
+    ScanFilter appleIBeaconFilter = buildAppleManufacturerFilter();
+    if (appleIBeaconFilter != null) {
+      filters.add(appleIBeaconFilter);
+    }
+
+    ScanFilter eddystoneFilter = buildEddystoneFilter();
+    if (eddystoneFilter != null) {
+      filters.add(eddystoneFilter);
+    }
+
+    for (BeaconConfig beacon : configBeacons) {
+      ScanFilter serviceFilter = buildServiceUuidFilter(beacon.getUuid());
+      if (serviceFilter != null) {
+        filters.add(serviceFilter);
+      }
+    }
+    return filters;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private ScanFilter buildEddystoneFilter() {
+    try {
+      return new ScanFilter.Builder()
+              .setServiceUuid(ParcelUuid.fromString("0000FEAA-0000-1000-8000-00805F9B34FB"))
+              .build();
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private ScanFilter buildAppleManufacturerFilter() {
+    try {
+      return new ScanFilter.Builder()
+              .setManufacturerData(0x004C, null)
+              .build();
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private ScanFilter buildServiceUuidFilter(String uuidString) {
+    try {
+      UUID uuid = UUID.fromString(uuidString);
+      return new ScanFilter.Builder()
+              .setServiceUuid(new ParcelUuid(uuid))
+              .build();
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private ScanCallback createScanCallback() {
+    return new ScanCallback() {
+      @Override
+      public void onScanResult(int callbackType, ScanResult result) {
+        handleScanResult(result);
+      }
+
+      @Override
+      public void onBatchScanResults(List<ScanResult> results) {
+        if (results == null) {
+          return;
+        }
+        for (ScanResult result : results) {
+          handleScanResult(result);
+        }
+      }
+
+      @Override
+      public void onScanFailed(int errorCode) {
+        Logger.e(LOG_TAG, "BeaconManager: scan failed with error code " + errorCode);
+        scanning = false;
+      }
+    };
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private void handleScanResult(ScanResult result) {
+    try {
+      if (debugScanAllBeacons) {
+        logRawScanResult(result);
+      }
+      DetectedBeacon detected = BeaconParser.parse(result);
+      if (detected == null || detected.getUuid() == null) {
+        return;
+      }
+      if (debugScanAllBeacons) {
+        Logger.d(LOG_TAG, "BeaconManager: detected " + detected.getType() + " beacon uuid="
+                + detected.getUuid() + " major=" + detected.getMajor() + " minor=" + detected.getMinor()
+                + " rssi=" + detected.getRssi());
+      }
+
+      BeaconConfig matched = matchBeacon(detected.getUuid());
+      if (matched == null) {
+        if (debugScanAllBeacons) {
+          Logger.d(LOG_TAG, "BeaconManager: uuid " + detected.getUuid()
+                  + " does not match any configured beacon, ignoring.");
+        }
+        return;
+      }
+      if (isInCooldown(detected.getUuid())) {
+        if (debugScanAllBeacons) {
+          Logger.d(LOG_TAG, "BeaconManager: uuid " + detected.getUuid()
+                  + " matched but is within cooldown window, ignoring.");
+        }
+        return;
+      }
+      markTriggered(detected.getUuid());
+      onBeaconMatched(detected, matched);
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: error handling scan result.", t);
+    }
+  }
+
+  /**
+   * Logs raw BLE advertisement details for diagnostics and debugging.
+   * Helps inspect received beacon data and verify scanner results.
+   */
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private void logRawScanResult(ScanResult result) {
+    try {
+      if (result == null) {
+        return;
+      }
+      String address = result.getDevice() != null ? result.getDevice().getAddress() : "?";
+      StringBuilder sb = new StringBuilder("BeaconManager RAW -> addr=").append(address)
+              .append(", rssi=").append(result.getRssi());
+
+      ScanRecord record = result.getScanRecord();
+      if (record != null) {
+        sb.append(", name=").append(record.getDeviceName());
+        if (record.getServiceUuids() != null) {
+          sb.append(", services=").append(record.getServiceUuids());
+        }
+        android.util.SparseArray<byte[]> mfg = record.getManufacturerSpecificData();
+        if (mfg != null && mfg.size() > 0) {
+          for (int i = 0; i < mfg.size(); i++) {
+            int id = mfg.keyAt(i);
+            sb.append(", mfgId=0x").append(Integer.toHexString(id))
+                    .append("[").append(bytesToHex(mfg.valueAt(i))).append("]");
+          }
+        }
+        sb.append(", raw=").append(bytesToHex(record.getBytes()));
+      }
+      Logger.d(LOG_TAG, sb.toString());
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: error logging raw scan result.", t);
+    }
+  }
+
+  private BeaconConfig matchBeacon(String detectedUuid) {
+    if (detectedUuid == null) {
+      return null;
+    }
+    for (BeaconConfig beacon : configBeacons) {
+      if (detectedUuid.equalsIgnoreCase(beacon.getUuid())) {
+        return beacon;
+      }
+    }
+    return null;
+  }
+
+  private boolean isInCooldown(String uuid) {
+    Long last = lastTriggeredAt.get(uuid.toLowerCase());
+    if (last == null) {
+      return false;
+    }
+    return (System.currentTimeMillis() - last) < cooldownMs;
+  }
+
+  private void markTriggered(String uuid) {
+    lastTriggeredAt.put(uuid.toLowerCase(), System.currentTimeMillis());
+  }
+
+  /**
+   * Handles a matched beacon by tracking its event and notifying the registered listener.
+   */
+  private void onBeaconMatched(DetectedBeacon detected, BeaconConfig matched) {
+    Logger.d(LOG_TAG, "BeaconManager: matched beacon '" + matched.getUuid() + "' -> trackEvent('"
+            + matched.getEventName() + "').");
+    try {
+      CleverPush.getInstance(appContext).trackEvent(matched.getEventName());
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: failed to trackEvent for matched beacon.", t);
+    }
+
+    final BeaconDetectedListener currentListener = listener;
+    if (currentListener != null) {
+      handler.post(() -> {
+        try {
+          currentListener.onBeaconDetected(detected, matched);
+        } catch (Throwable t) {
+          Logger.e(LOG_TAG, "BeaconManager: error in onBeaconDetected callback.", t);
+        }
+      });
+    }
+  }
+
+  /**
+   * Returns whether the app process is currently in the foreground.
+   * Defaults to true if the check fails.
+   */
+  private boolean isAppInForeground() {
+    try {
+      ActivityManager.RunningAppProcessInfo info = new ActivityManager.RunningAppProcessInfo();
+      ActivityManager.getMyMemoryState(info);
+      return info.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+              || info.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE;
+    } catch (Throwable t) {
+      return true;
+    }
+  }
+
+  /**
+   * Handles app foreground/background transitions and
+   * triggers actions when returning to the foreground.
+   */
+  private synchronized void updateForegroundTransition(boolean nowForeground) {
+    if (nowForeground && !foregroundTransitionState) {
+      foregroundTransitionState = true;
+      onEnterForeground();
+    } else if (!nowForeground && foregroundTransitionState) {
+      foregroundTransitionState = false;
+    }
+  }
+
+  @SuppressWarnings("MissingPermission")
+  private void onEnterForeground() {
+    foreground = true;
+    if (retriggerOnForeground) {
+      lastTriggeredAt.clear();
+    }
+    if (!isStarted()) {
+      return;
+    }
+    Logger.d(LOG_TAG, "BeaconManager: app entered foreground - re-arming beacon events and scanning now.");
+    handler.removeCallbacksAndMessages(null);
+    stopScanInternal();
+    scheduleScanCycle(0);
+  }
+
+  private void registerLifecycleCallbacks() {
+    if (lifecycleRegistered) {
+      return;
+    }
+    if (!(appContext instanceof Application)) {
+      return;
+    }
+    try {
+      ((Application) appContext).registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
+        private int startedActivities = 0;
+
+        @Override
+        public void onActivityStarted(@NonNull Activity activity) {
+          startedActivities++;
+          foreground = true;
+          updateForegroundTransition(startedActivities > 0);
+        }
+
+        @Override
+        public void onActivityStopped(@NonNull Activity activity) {
+          if (startedActivities > 0) {
+            startedActivities--;
+          }
+          if (startedActivities == 0) {
+            foreground = false;
+          }
+          updateForegroundTransition(startedActivities > 0);
+        }
+
+        @Override
+        public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
+        }
+
+        @Override
+        public void onActivityResumed(@NonNull Activity activity) {
+        }
+
+        @Override
+        public void onActivityPaused(@NonNull Activity activity) {
+        }
+
+        @Override
+        public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
+        }
+
+        @Override
+        public void onActivityDestroyed(@NonNull Activity activity) {
+        }
+      });
+      lifecycleRegistered = true;
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: failed to register lifecycle callbacks.", t);
+    }
+  }
+
+  /**
+   * Logs diagnostic information relevant to BLE detection and setup.
+   * Useful for troubleshooting beacon scanning issues.
+   */
+  private void logDiagnostics() {
+    try {
+      StringBuilder sb = new StringBuilder("BeaconManager diagnostics -> ");
+      sb.append("androidSdk=").append(Build.VERSION.SDK_INT);
+      sb.append(", device=").append(Build.MANUFACTURER).append(" ").append(Build.MODEL);
+      sb.append(", isEmulator=").append(isProbablyEmulator());
+      sb.append(", bleSupported=").append(isBleSupported());
+      sb.append(", bluetoothEnabled=").append(isBluetoothEnabled());
+      sb.append(", locationServicesOn=").append(isLocationServicesEnabled());
+      sb.append(", debugScanAll=").append(debugScanAllBeacons);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        sb.append(", BLUETOOTH_SCAN=").append(hasPermission("android.permission.BLUETOOTH_SCAN"));
+        sb.append(", BLUETOOTH_CONNECT=").append(hasPermission("android.permission.BLUETOOTH_CONNECT"));
+      } else {
+        sb.append(", ACCESS_FINE_LOCATION=").append(hasPermission("android.permission.ACCESS_FINE_LOCATION"));
+      }
+      sb.append(", configuredBeacons=").append(configBeacons.size());
+      Logger.d(LOG_TAG, sb.toString());
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: error logging diagnostics.", t);
+    }
+  }
+
+  private boolean hasPermission(String permission) {
+    try {
+      return ContextCompat.checkSelfPermission(appContext, permission) == PackageManager.PERMISSION_GRANTED;
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns whether system location services are enabled.
+   * Required for BLE scanning on Android 11 and below.
+   */
+  public boolean isLocationServicesEnabled() {
+    try {
+      LocationManager lm = (LocationManager) appContext.getSystemService(Context.LOCATION_SERVICE);
+      if (lm == null) {
+        return false;
+      }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        return lm.isLocationEnabled();
+      }
+      return lm.isProviderEnabled(LocationManager.GPS_PROVIDER)
+              || lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+
+  private boolean isProbablyEmulator() {
+    String fingerprint = Build.FINGERPRINT == null ? "" : Build.FINGERPRINT;
+    String model = Build.MODEL == null ? "" : Build.MODEL;
+    String product = Build.PRODUCT == null ? "" : Build.PRODUCT;
+    return fingerprint.startsWith("generic")
+            || fingerprint.startsWith("unknown")
+            || fingerprint.contains("emulator")
+            || model.contains("Emulator")
+            || model.contains("Android SDK built for")
+            || product.contains("sdk")
+            || product.contains("emulator")
+            || Build.HARDWARE.contains("goldfish")
+            || Build.HARDWARE.contains("ranchu");
+  }
+
+  public boolean isBleSupported() {
+    return appContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE);
+  }
+
+  public boolean isBluetoothEnabled() {
+    BluetoothAdapter adapter = getBluetoothAdapter();
+    return adapter != null && adapter.isEnabled();
+  }
+
+  private BluetoothAdapter getBluetoothAdapter() {
+    try {
+      BluetoothManager manager = (BluetoothManager) appContext.getSystemService(Context.BLUETOOTH_SERVICE);
+      if (manager != null) {
+        return manager.getAdapter();
+      }
+    } catch (Throwable t) {
+      Logger.e(LOG_TAG, "BeaconManager: error getting BluetoothManager.", t);
+    }
+    return BluetoothAdapter.getDefaultAdapter();
+  }
+}

--- a/cleverpush/src/main/java/com/cleverpush/beacon/BeaconParser.java
+++ b/cleverpush/src/main/java/com/cleverpush/beacon/BeaconParser.java
@@ -1,0 +1,164 @@
+package com.cleverpush.beacon;
+
+import android.bluetooth.le.ScanRecord;
+import android.bluetooth.le.ScanResult;
+import android.os.Build;
+import android.os.ParcelUuid;
+import android.util.SparseArray;
+
+import androidx.annotation.RequiresApi;
+
+import java.util.List;
+import java.util.Map;
+
+public class BeaconParser {
+
+  private static final int APPLE_MANUFACTURER_ID = 0x004C;
+  private static final byte IBEACON_TYPE = 0x02;
+  private static final byte IBEACON_LENGTH = 0x15; // 21 bytes following
+  private static final int ALTBEACON_CODE = 0xBEAC;
+
+  private static final ParcelUuid EDDYSTONE_SERVICE =
+          ParcelUuid.fromString("0000FEAA-0000-1000-8000-00805F9B34FB");
+  private static final byte EDDYSTONE_FRAME_UID = 0x00;
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  public static DetectedBeacon parse(ScanResult scanResult) {
+    if (scanResult == null) {
+      return null;
+    }
+    try {
+      ScanRecord record = scanResult.getScanRecord();
+      if (record == null) {
+        return null;
+      }
+
+      String address = scanResult.getDevice() != null ? scanResult.getDevice().getAddress() : null;
+      int rssi = scanResult.getRssi();
+
+      DetectedBeacon beacon = parseIBeacon(record, rssi, address);
+      if (beacon != null) {
+        return beacon;
+      }
+      beacon = parseAltBeacon(record, rssi, address);
+      if (beacon != null) {
+        return beacon;
+      }
+      beacon = parseEddystone(record, rssi, address);
+      if (beacon != null) {
+        return beacon;
+      }
+      return parseGeneric(record, rssi, address);
+    } catch (Throwable ignored) {
+      // Never let a malformed packet crash the scan callback.
+      return null;
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private static DetectedBeacon parseIBeacon(ScanRecord record, int rssi, String address) {
+    byte[] data = record.getManufacturerSpecificData(APPLE_MANUFACTURER_ID);
+    if (data == null || data.length < 23) {
+      return null;
+    }
+    int offset = -1;
+    if (data[0] == IBEACON_TYPE && data[1] == IBEACON_LENGTH) {
+      offset = 0;
+    } else {
+      for (int i = 0; i + 23 <= data.length; i++) {
+        if (data[i] == IBEACON_TYPE && data[i + 1] == IBEACON_LENGTH) {
+          offset = i;
+          break;
+        }
+      }
+    }
+    if (offset < 0 || offset + 23 > data.length) {
+      return null;
+    }
+
+    String uuid = formatUuid(toHex(data, offset + 2, 16));
+    int major = ((data[offset + 18] & 0xFF) << 8) | (data[offset + 19] & 0xFF);
+    int minor = ((data[offset + 20] & 0xFF) << 8) | (data[offset + 21] & 0xFF);
+    int txPower = data[offset + 22]; // signed
+
+    return new DetectedBeacon(uuid, major, minor, rssi, txPower, address, DetectedBeacon.TYPE_IBEACON);
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private static DetectedBeacon parseAltBeacon(ScanRecord record, int rssi, String address) {
+    SparseArray<byte[]> all = record.getManufacturerSpecificData();
+    if (all == null) {
+      return null;
+    }
+    for (int i = 0; i < all.size(); i++) {
+      byte[] data = all.valueAt(i);
+      if (data == null || data.length < 24) {
+        continue;
+      }
+      int code = ((data[0] & 0xFF) << 8) | (data[1] & 0xFF);
+      if (code != ALTBEACON_CODE) {
+        continue;
+      }
+      String uuid = formatUuid(toHex(data, 2, 16));
+      int id2 = ((data[18] & 0xFF) << 8) | (data[19] & 0xFF);
+      int id3 = ((data[20] & 0xFF) << 8) | (data[21] & 0xFF);
+      int txPower = data[22]; // signed reference RSSI
+      return new DetectedBeacon(uuid, id2, id3, rssi, txPower, address, DetectedBeacon.TYPE_ALTBEACON);
+    }
+    return null;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private static DetectedBeacon parseEddystone(ScanRecord record, int rssi, String address) {
+    Map<ParcelUuid, byte[]> serviceData = record.getServiceData();
+    if (serviceData == null) {
+      return null;
+    }
+    byte[] data = serviceData.get(EDDYSTONE_SERVICE);
+    if (data == null || data.length < 18) {
+      return null;
+    }
+    if (data[0] != EDDYSTONE_FRAME_UID) {
+      return null; // not a UID frame (URL/TLM/EID frames carry no stable id we can match)
+    }
+    int txPower = data[1]; // signed calibrated tx power at 0m
+    String uuid = formatUuid(toHex(data, 2, 16)); // namespace (10) + instance (6) = 16 bytes
+    return new DetectedBeacon(uuid, null, null, rssi, txPower, address, DetectedBeacon.TYPE_EDDYSTONE);
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private static DetectedBeacon parseGeneric(ScanRecord record, int rssi, String address) {
+    List<ParcelUuid> serviceUuids = record.getServiceUuids();
+    if (serviceUuids == null || serviceUuids.isEmpty()) {
+      return null;
+    }
+    ParcelUuid first = serviceUuids.get(0);
+    if (first == null) {
+      return null;
+    }
+    String uuid = first.getUuid().toString();
+    return new DetectedBeacon(uuid, null, null, rssi, null, address, DetectedBeacon.TYPE_GENERIC);
+  }
+
+  private static String toHex(byte[] data, int start, int length) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = start; i < start + length && i < data.length; i++) {
+      sb.append(String.format("%02x", data[i] & 0xFF));
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Turns a 32-char hex string into the canonical 8-4-4-4-12 UUID format.
+   */
+  private static String formatUuid(String hex) {
+    if (hex == null || hex.length() != 32) {
+      return hex;
+    }
+    return hex.substring(0, 8) + "-"
+            + hex.substring(8, 12) + "-"
+            + hex.substring(12, 16) + "-"
+            + hex.substring(16, 20) + "-"
+            + hex.substring(20, 32);
+  }
+}

--- a/cleverpush/src/main/java/com/cleverpush/beacon/DetectedBeacon.java
+++ b/cleverpush/src/main/java/com/cleverpush/beacon/DetectedBeacon.java
@@ -1,0 +1,61 @@
+package com.cleverpush.beacon;
+
+public class DetectedBeacon {
+
+  public static final String TYPE_IBEACON = "ibeacon";
+  public static final String TYPE_ALTBEACON = "altbeacon";
+  public static final String TYPE_EDDYSTONE = "eddystone";
+  public static final String TYPE_GENERIC = "generic";
+  private final String uuid;
+  private final Integer major;
+  private final Integer minor;
+  private final int rssi;
+  private final Integer txPower;
+  private final String bluetoothAddress;
+  private final String type;
+
+  public DetectedBeacon(String uuid, Integer major, Integer minor, int rssi, Integer txPower,
+                        String bluetoothAddress, String type) {
+    this.uuid = uuid == null ? null : uuid.trim().toLowerCase();
+    this.major = major;
+    this.minor = minor;
+    this.rssi = rssi;
+    this.txPower = txPower;
+    this.bluetoothAddress = bluetoothAddress;
+    this.type = type;
+  }
+
+  public String getUuid() {
+    return uuid;
+  }
+
+  public Integer getMajor() {
+    return major;
+  }
+
+  public Integer getMinor() {
+    return minor;
+  }
+
+  public int getRssi() {
+    return rssi;
+  }
+
+  public Integer getTxPower() {
+    return txPower;
+  }
+
+  public String getBluetoothAddress() {
+    return bluetoothAddress;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public String toString() {
+    return "DetectedBeacon{uuid='" + uuid + "', major=" + major + ", minor=" + minor
+            + ", rssi=" + rssi + ", txPower=" + txPower + ", type='" + type + "'}";
+  }
+}

--- a/cleverpush/src/main/java/com/cleverpush/listener/BeaconDetectedListener.java
+++ b/cleverpush/src/main/java/com/cleverpush/listener/BeaconDetectedListener.java
@@ -1,0 +1,17 @@
+package com.cleverpush.listener;
+
+import com.cleverpush.beacon.BeaconConfig;
+import com.cleverpush.beacon.DetectedBeacon;
+
+/**
+ * Optional callback that is invoked only AFTER a scanned BLE/iBeacon advertisement has been
+ * successfully matched against a beacon configured in the CleverPush channel config.
+ *
+ * The callback receives both the raw detected beacon (UUID/major/minor/rssi) and the matched
+ * configuration object (name/eventName/storeId), so the integrating app can react if it wants to.
+ * Registering this callback is completely optional - the SDK already tracks the configured event
+ * automatically before the callback fires.
+ */
+public interface BeaconDetectedListener {
+  void onBeaconDetected(DetectedBeacon detectedBeacon, BeaconConfig matchedBeacon);
+}


### PR DESCRIPTION
Add BLE/iBeacon monitoring with automatic event tracking

* Add `initBeacons()` / `initBeacons(Activity)` for beacon setup and monitoring
* Add `onBeaconDetected(listener)` optional callback for matched beacons
* Add `setBeaconEventInterval(minutes)` to control beacon re-trigger frequency per app session
* Add `setBeaconDebugScanAll(boolean)` for diagnostic unfiltered scanning and verbose logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New background BLE scanning and location/Bluetooth permission prompts affect battery and privacy; changes are gated on `initBeacons()` and channel config but touch shared permission and lifecycle paths used by other SDK features.
> 
> **Overview**
> Adds **Android BLE/iBeacon monitoring** so beacons defined in channel config can **auto-fire `trackEvent`** when advertisements match configured UUIDs.
> 
> **`CleverPush`** exposes `initBeacons()` / `initBeacons(Activity)` (loads `beacons` from channel config, defers until a real host activity, requests permissions), optional `onBeaconDetected`, `setBeaconEventInterval(minutes)`, and `setBeaconDebugScanAll`. **`PermissionActivity`** now supports **multi-permission** requests via `INTENT_EXTRA_PERMISSION_TYPES` and `keyFor()`; **`ActivityLifecycleListener.isValidHostActivity`** excludes **`PermissionActivity`** so permission flows don’t block deferred init.
> 
> New **`com.cleverpush.beacon`** stack: **`BeaconManager`** runs filtered scan windows (foreground/background cadence, Bluetooth on/off resume, cooldown, optional debug unfiltered scan), **`BeaconParser`** for iBeacon/AltBeacon/Eddystone/generic, **`BeaconConfig`** from JSON, and **`BeaconDetectedListener`**. Manifest adds Bluetooth/location permissions and optional BLE hardware feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148c2696b851830987d88360dd2d4e9a875001d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds BLE/iBeacon monitoring on Android that auto-tracks channel-configured beacon events and optionally notifies the app. Addresses CP-11480 with filtered, battery-aware scanning that pauses when Bluetooth is off, skips unsupported devices, and resumes automatically.

- **New Features**
  - `CleverPush.initBeacons()` / `initBeacons(Activity)` to start monitoring; defers until a valid Activity (excluding `PermissionActivity`) and requests required permissions in one flow (Android 12+: `BLUETOOTH_SCAN`/`BLUETOOTH_CONNECT` + location).
  - `CleverPush.onBeaconDetected(listener)` optional callback after a matched beacon with detected and config details.
  - `CleverPush.setBeaconEventInterval(minutes)` to control re-trigger cooldown; cooldown resets when the app returns to foreground.
  - `CleverPush.setBeaconDebugScanAll(boolean)` for unfiltered scans and verbose raw-ad logs.
  - Foreground/background scan cycles with hardware scan filters; parses iBeacon, AltBeacon, Eddystone, and generic service UUIDs; auto-pauses when Bluetooth is off and resumes when it’s turned back on; no-op on devices without BLE or below Android 5.0.

- **Migration**
  - Call `CleverPush.initBeacons()` once the app is ready; optionally set the interval and register `onBeaconDetected`.
  - Ensure users grant location (and on Android 12+, Bluetooth) permissions; the SDK will prompt if missing.

<sup>Written for commit ae483cf7b8b3c3fe2abe112a572c1b892cdcf2cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

