### PR TITLE
feature/cp-11868-android-in-app-banner-test-bypassconditions-support

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -20,6 +20,7 @@ public class CleverPushPreferences {
   public static final String NOTIFICATIONS = "CleverPush_NOTIFICATIONS"; // deprecated, now using NOTIFICATIONS_JSON
   public static final String NOTIFICATIONS_JSON = "CleverPush_NOTIFICATIONS_JSON";
   public static final String LAST_NOTIFICATION_ID = "CleverPush_LAST_NOTIFICATION_ID";
+  public static final String NOTIFICATION_BANNER_BYPASS_CONDITIONS = "CleverPush_NOTIFICATION_BANNER_BYPASS_CONDITIONS";
   public static final String LAST_CLICKED_NOTIFICATION_ID = "CleverPush_LAST_CLICKED_NOTIFICATION_ID";
   public static final String LAST_CLICKED_NOTIFICATION_TIME = "CleverPush_LAST_CLICKED_NOTIFICATION_TIME";
   public static final String APP_OPENS = "CleverPush_APP_OPENS";

--- a/cleverpush/src/main/java/com/cleverpush/Notification.java
+++ b/cleverpush/src/main/java/com/cleverpush/Notification.java
@@ -56,6 +56,8 @@ public class Notification implements Serializable {
   String voucherCode;
   @SerializedName("autoHandleDeepLink")
   Boolean autoHandleDeepLink;
+  @SerializedName("bypassConditions")
+  Boolean bypassConditions;
 
   Boolean read = false;
   Boolean fromApi = false;
@@ -277,6 +279,10 @@ public class Notification implements Serializable {
     return autoHandleDeepLink != null && autoHandleDeepLink;
   }
 
+  public Boolean getBypassConditions() {
+    return bypassConditions;
+  }
+
   public String getCurrentDate() {
     try {
       SimpleDateFormat dateFormat;
@@ -332,6 +338,7 @@ public class Notification implements Serializable {
     copiedNotification.extender = this.extender;
     copiedNotification.rawPayload = this.rawPayload;
     copiedNotification.requestId = this.requestId;
+    copiedNotification.bypassConditions = this.bypassConditions;
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
       copiedNotification.notificationChannel = this.notificationChannel;
     }

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -1908,9 +1908,54 @@ public class AppBannerModule {
     });
   }
 
+  boolean shouldBypassBannerConditions(String notificationId) {
+    if (notificationId == null || notificationId.isEmpty()) {
+      return false;
+    }
+    try {
+      String storedJson = sharedPreferences.getString(CleverPushPreferences.NOTIFICATION_BANNER_BYPASS_CONDITIONS, null);
+      if (storedJson == null) {
+        return false;
+      }
+      Type type = new TypeToken<Map<String, Boolean>>() {
+      }.getType();
+      Map<String, Boolean> bypassMap = new Gson().fromJson(storedJson, type);
+      return bypassMap != null && Boolean.TRUE.equals(bypassMap.get(notificationId));
+    } catch (Exception e) {
+      Logger.e(TAG, "Error reading banner bypassConditions flag", e);
+      return false;
+    }
+  }
+
+  void removeBannerBypassCondition(String notificationId) {
+    if (notificationId == null || notificationId.isEmpty()) {
+      return;
+    }
+    try {
+      String storedJson = sharedPreferences.getString(CleverPushPreferences.NOTIFICATION_BANNER_BYPASS_CONDITIONS, null);
+      if (storedJson == null) {
+        return;
+      }
+      Type type = new TypeToken<Map<String, Boolean>>() {
+      }.getType();
+      Map<String, Boolean> bypassMap = new Gson().fromJson(storedJson, type);
+      if (bypassMap == null || !bypassMap.containsKey(notificationId)) {
+        return;
+      }
+      bypassMap.remove(notificationId);
+      editor.putString(CleverPushPreferences.NOTIFICATION_BANNER_BYPASS_CONDITIONS, new Gson().toJson(bypassMap, type));
+      editor.apply();
+    } catch (Exception e) {
+      Logger.e(TAG, "Error clearing banner bypassConditions flag", e);
+    }
+  }
+
   private void validatePushBannerTrigger(Banner banner, AppBannerPopup popup, boolean force, AppBannerClosedListener appBannerClosedListener, String notificationId) {
     boolean triggers = false, isTriggerCondition = false, isTargetEvent = false;
     int delaySeconds = 0;
+
+    boolean bypassConditions = shouldBypassBannerConditions(notificationId);
+
     if (banner.getTriggerType() == BannerTriggerType.Conditions) {
       isTriggerCondition = true;
       for (BannerTrigger trigger : banner.getTriggers()) {
@@ -1967,7 +2012,7 @@ public class AppBannerModule {
     }
 
     boolean targetEvents = true;
-    if (banner.getEventFilters() != null && banner.getEventFilters().size() > 0) {
+    if (!bypassConditions && banner.getEventFilters() != null && banner.getEventFilters().size() > 0) {
       isTargetEvent = true;
       for (BannerTargetEvent bannerTargetEvent : banner.getEventFilters()) {
         boolean targetConditionTrue;
@@ -2070,7 +2115,8 @@ public class AppBannerModule {
           return;
         }
 
-        if (!isBannerTargetingAllowed(banner)) {
+        boolean bypassConditions = shouldBypassBannerConditions(notificationId);
+        if (!bypassConditions && !isBannerTargetingAllowed(banner)) {
           Logger.d(TAG, "Skipping Banner " + banner.getId() + " because: Targeting not allowed");
           return;
         }
@@ -2102,6 +2148,8 @@ public class AppBannerModule {
 
       bannerPopup.init();
       bannerPopup.show();
+
+      removeBannerBypassCondition(notificationId);
 
       sharedPreferences.edit().putBoolean(CleverPushPreferences.APP_BANNER_SHOWING_IN_PROGRESS, true).apply();
 

--- a/cleverpush/src/main/java/com/cleverpush/service/NotificationDataProcessor.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/NotificationDataProcessor.java
@@ -248,7 +248,10 @@ public class NotificationDataProcessor {
         return;
       }
 
-      boolean shouldBypass = Boolean.TRUE.equals(notification.getBypassConditions());
+      if (!Boolean.TRUE.equals(notification.getBypassConditions())) {
+        return;
+      }
+
       String notificationId = notification.getId();
 
       Type type = new TypeToken<Map<String, Boolean>>() {
@@ -262,7 +265,7 @@ public class NotificationDataProcessor {
         bypassMap = new HashMap<>();
       }
 
-      bypassMap.put(notificationId, shouldBypass);
+      bypassMap.put(notificationId, true);
       sharedPreferences.edit()
           .putString(CleverPushPreferences.NOTIFICATION_BANNER_BYPASS_CONDITIONS, new Gson().toJson(bypassMap, type))
           .apply();

--- a/cleverpush/src/main/java/com/cleverpush/service/NotificationDataProcessor.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/NotificationDataProcessor.java
@@ -248,10 +248,7 @@ public class NotificationDataProcessor {
         return;
       }
 
-      if (!Boolean.TRUE.equals(notification.getBypassConditions())) {
-        return;
-      }
-
+      boolean shouldBypass = Boolean.TRUE.equals(notification.getBypassConditions());
       String notificationId = notification.getId();
 
       Type type = new TypeToken<Map<String, Boolean>>() {
@@ -261,6 +258,16 @@ public class NotificationDataProcessor {
       if (storedJson != null) {
         bypassMap = new Gson().fromJson(storedJson, type);
       }
+
+      if (!shouldBypass) {
+        if (bypassMap != null && bypassMap.remove(notificationId) != null) {
+          sharedPreferences.edit()
+              .putString(CleverPushPreferences.NOTIFICATION_BANNER_BYPASS_CONDITIONS, new Gson().toJson(bypassMap, type))
+              .apply();
+        }
+        return;
+      }
+
       if (bypassMap == null) {
         bypassMap = new HashMap<>();
       }

--- a/cleverpush/src/main/java/com/cleverpush/service/NotificationDataProcessor.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/NotificationDataProcessor.java
@@ -65,6 +65,8 @@ public class NotificationDataProcessor {
     SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(CleverPush.context);
     SharedPreferences.Editor editor = sharedPreferences.edit();
 
+    storeBannerBypassCondition(sharedPreferences, notification);
+
     // default behaviour: do not show notification if application is in the foreground
     // ways to bypass this:
     // - use NotificationReceivedCallbackListener and return false
@@ -237,6 +239,36 @@ public class NotificationDataProcessor {
     }
 
     return true;
+  }
+
+  private static void storeBannerBypassCondition(SharedPreferences sharedPreferences, Notification notification) {
+    try {
+      String appBanner = notification.getAppBanner();
+      if (appBanner == null || appBanner.isEmpty()) {
+        return;
+      }
+
+      boolean shouldBypass = Boolean.TRUE.equals(notification.getBypassConditions());
+      String notificationId = notification.getId();
+
+      Type type = new TypeToken<Map<String, Boolean>>() {
+      }.getType();
+      String storedJson = sharedPreferences.getString(CleverPushPreferences.NOTIFICATION_BANNER_BYPASS_CONDITIONS, null);
+      Map<String, Boolean> bypassMap = null;
+      if (storedJson != null) {
+        bypassMap = new Gson().fromJson(storedJson, type);
+      }
+      if (bypassMap == null) {
+        bypassMap = new HashMap<>();
+      }
+
+      bypassMap.put(notificationId, shouldBypass);
+      sharedPreferences.edit()
+          .putString(CleverPushPreferences.NOTIFICATION_BANNER_BYPASS_CONDITIONS, new Gson().toJson(bypassMap, type))
+          .apply();
+    } catch (Exception e) {
+      Logger.e(LOG_TAG, "Error storing banner bypassConditions flag", e);
+    }
   }
 
   private static void handleSilentNotificationBanner(Notification notification, SharedPreferences sharedPreferences,


### PR DESCRIPTION
Add support for bypassConditions on banners attached to push notifications. When a push notification has an attached banner and bypassConditions is true, the banner's targeting conditions are skipped so the banner is shown directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in server flag weakens banner targeting and event filters for push-linked banners only; scope is limited but affects who sees marketing UI.
> 
> **Overview**
> Push notifications can now carry **`bypassConditions`** so attached in-app banners can be shown for **banner testing** (CP-11868) without normal audience rules blocking display.
> 
> On delivery, when a notification has an **`appBanner`** and **`bypassConditions`** is true, the SDK persists a per-notification flag under **`NOTIFICATION_BANNER_BYPASS_CONDITIONS`**. **`AppBannerModule`** reads that flag to **skip event filters** during push-banner validation and **skip targeting** (`isBannerTargetingAllowed`) when showing the banner. The flag is **removed after the banner is shown**.
> 
> The **`Notification`** model gains the serialized field plus **`copy()`** support; **`NotificationDataProcessor`** writes the flag early in processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 694fa7fd7fab93fd302ed6804e535975f9eb2ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support to bypass banner targeting for push-attached banners when `bypassConditions=true`, so the banner shows without targeting checks or event filters. Aligns with CP-11868.

- **New Features**
  - Store per-notification bypass flags in `SharedPreferences` under `CleverPush_NOTIFICATION_BANNER_BYPASS_CONDITIONS`; remove the entry after the banner is shown and clear stale entries when `bypassConditions=false`.
  - In `AppBannerModule`, when the bypass flag is set for the push `notificationId`, skip `isBannerTargetingAllowed` and all `eventFilters` before showing the banner.
  - Add `bypassConditions` to `Notification` (serialized), with a getter and support in `copy()`.

<sup>Written for commit 87bc46f7377072aee0fd044b8bb3e956b557def0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

