### PR TITLE
hotfix/cp-12056-banner-attached-to-push-not-working-when-app-banner-has

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -107,10 +107,10 @@ public class AppBannerModule {
   private Set<String> bannerDeliveredList = new HashSet<>();
   public String currentEventId = null;
   Set<String> currentNotificationDeeplink = new HashSet<>();
-  boolean isBannerFromNotification = false;
   private TriggeredEvent currentEvent = null;
   private AppBannerClosedListener appBannerClosedListener;
   Set<String> shownBanners = new HashSet<>();
+  private final Map<String, PendingPushBannerValidation> pendingPushBannerValidations = new HashMap<>();
   private final Queue<PendingBannerRequest> pendingBannerRequests = new LinkedList<>();
   private boolean isBannerRequestRunning = false;
   private boolean defaultBannersLoaded = false;
@@ -244,7 +244,6 @@ public class AppBannerModule {
     }
     boolean FromNotification = false;
     if (notificationId != null && !notificationId.isEmpty()) {
-      isBannerFromNotification = true;
       FromNotification = true;
       bannersPath += "&notificationId=" + notificationId;
     }
@@ -253,8 +252,11 @@ public class AppBannerModule {
     CleverPushHttpClient.getWithRetry(bannersPath, new CleverPushHttpClient.ResponseHandler() {
       @Override
       public void onSuccess(String response) {
-        allBanners = new LinkedList<>();
-        allNotificationBanners = new LinkedList<>();
+        if (finalFromNotification) {
+          allNotificationBanners = new LinkedList<>();
+        } else {
+          allBanners = new LinkedList<>();
+        }
         try {
           JSONObject responseJson = new JSONObject(response);
           JSONArray rawBanners = responseJson.getJSONArray("banners");
@@ -569,7 +571,24 @@ public class AppBannerModule {
     events.add(event);
     currentEventId = event.getId();
     currentEvent = event;
+    revalidatePendingPushBanners();
     this.startup();
+  }
+
+  private void revalidatePendingPushBanners() {
+    List<PendingPushBannerValidation> pendingValidations;
+    synchronized (pendingPushBannerValidations) {
+      if (pendingPushBannerValidations.isEmpty()) {
+        return;
+      }
+      pendingValidations = new ArrayList<>(pendingPushBannerValidations.values());
+      pendingPushBannerValidations.clear();
+    }
+
+    for (PendingPushBannerValidation pending : pendingValidations) {
+      validatePushBannerTrigger(pending.banner, getAppBannerPopup(pending.banner), pending.force,
+          pending.appBannerClosedListener, pending.notificationId);
+    }
   }
 
   public void getBannerList(AppBannersListener listener, String channelId) {
@@ -1143,7 +1162,10 @@ public class AppBannerModule {
       }
 
       if (condition.getEventProperties() == null || condition.getEventProperties().size() == 0) {
-        return true;
+        if (triggeredEvent.getProperties() == null || triggeredEvent.getProperties().isEmpty()) {
+          return true;
+        }
+        continue;
       }
 
       boolean conditionTrue = true;
@@ -1174,8 +1196,10 @@ public class AppBannerModule {
     for (BannerTriggerCondition triggerCondition : triggers) {
       if (currentEvent.getId() != null && currentEvent.getId().equals(triggerCondition.getEvent())) {
         if (triggerCondition.getEventProperties() == null || triggerCondition.getEventProperties().isEmpty()) {
-          currentEventMatches = true;
-          break;
+          currentEventMatches = currentEvent.getProperties() == null || currentEvent.getProperties().isEmpty();
+          if (currentEventMatches) {
+            break;
+          }
         } else {
           if (currentEvent.getProperties() != null) {
             boolean conditionTrue = true;
@@ -1714,13 +1738,7 @@ public class AppBannerModule {
 
       if (!contains) {
         getActivityLifecycleListener().setActivityInitializedListener(
-            () -> {
-              if (isBannerFromNotification) {
-                isBannerFromNotification = false;
-              } else {
-                filteredBanners.add(new AppBannerPopup(getCurrentActivity(), banner));
-              }
-            });
+            () -> filteredBanners.add(new AppBannerPopup(getCurrentActivity(), banner)));
       }
     }
   }
@@ -2057,11 +2075,15 @@ public class AppBannerModule {
     if (isTriggerCondition && isTargetEvent) {
       if (!targetEvents || !triggers) {
         Logger.d(TAG, "Skipping Notification Banner " + banner.getId() + " because: Trigger and Target Event not satisfied " + sessions);
+        if (!triggers) {
+          queuePendingPushBannerValidation(banner, force, appBannerClosedListener, notificationId);
+        }
         return;
       }
     } else if (isTriggerCondition) {
       if (!triggers) {
         Logger.d(TAG, "Skipping Notification Banner " + banner.getId() + " because: Trigger not satisfied " + sessions);
+        queuePendingPushBannerValidation(banner, force, appBannerClosedListener, notificationId);
         return;
       }
     } else if (isTargetEvent) {
@@ -2081,6 +2103,52 @@ public class AppBannerModule {
     } else {
       long delay = banner.getStartAt().getTime() - now.getTime();
       getHandler().postDelayed(() -> getHandler().post(() -> showBanner(popup, force, appBannerClosedListener, notificationId)), delay + (1000L * delaySeconds));
+    }
+  }
+
+  private void queuePendingPushBannerValidation(Banner banner, boolean force,
+                                                AppBannerClosedListener appBannerClosedListener, String notificationId) {
+    if (!hasEventTriggerCondition(banner)) {
+      return;
+    }
+    synchronized (pendingPushBannerValidations) {
+      pendingPushBannerValidations.put(banner.getId(),
+          new PendingPushBannerValidation(banner, force, appBannerClosedListener, notificationId));
+    }
+    Logger.d(TAG, "Queued Notification Banner " + banner.getId() + " for re-validation once its trigger event is tracked");
+  }
+
+  private boolean hasEventTriggerCondition(Banner banner) {
+    if (banner.getTriggerType() != BannerTriggerType.Conditions || banner.getTriggers() == null) {
+      return false;
+    }
+    for (BannerTrigger trigger : banner.getTriggers()) {
+      if (trigger.getConditions() == null) {
+        continue;
+      }
+      for (BannerTriggerCondition condition : trigger.getConditions()) {
+        if (condition.getType() != null
+            && condition.getType().equals(BannerTriggerConditionType.Event)
+            && condition.getEvent() != null) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static class PendingPushBannerValidation {
+    final Banner banner;
+    final boolean force;
+    final AppBannerClosedListener appBannerClosedListener;
+    final String notificationId;
+
+    PendingPushBannerValidation(Banner banner, boolean force,
+                                AppBannerClosedListener appBannerClosedListener, String notificationId) {
+      this.banner = banner;
+      this.force = force;
+      this.appBannerClosedListener = appBannerClosedListener;
+      this.notificationId = notificationId;
     }
   }
 

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerModule.java
@@ -111,6 +111,7 @@ public class AppBannerModule {
   private AppBannerClosedListener appBannerClosedListener;
   Set<String> shownBanners = new HashSet<>();
   private final Map<String, PendingPushBannerValidation> pendingPushBannerValidations = new HashMap<>();
+  private final Set<String> pushValidatedBannerIds = Collections.synchronizedSet(new HashSet<>());
   private final Queue<PendingBannerRequest> pendingBannerRequests = new LinkedList<>();
   private boolean isBannerRequestRunning = false;
   private boolean defaultBannersLoaded = false;
@@ -1737,6 +1738,10 @@ public class AppBannerModule {
       }
 
       if (!contains) {
+        if (pushValidatedBannerIds.remove(banner.getId())) {
+          Logger.d(TAG, "Skipping Banner " + banner.getId() + " because: already scheduled via push notification");
+          continue;
+        }
         getActivityLifecycleListener().setActivityInitializedListener(
             () -> filteredBanners.add(new AppBannerPopup(getCurrentActivity(), banner)));
       }
@@ -2092,6 +2097,8 @@ public class AppBannerModule {
         return;
       }
     }
+
+    pushValidatedBannerIds.add(banner.getId());
 
     Date now = new Date();
     if (banner.getStartAt().before(now)) {


### PR DESCRIPTION
Resolve event-triggered app banners not showing when events are tracked after push notification open

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and duplicate-prevention for in-app banner display from push; localized to AppBannerModule but affects marketing/UX flows.
> 
> **Overview**
> Fixes **push-attached app banners** that use **event triggers** but never appeared when the user tracked the event **after** opening the notification.
> 
> When `validatePushBannerTrigger` fails on triggers, banners with event conditions are **queued** and **re-run** from `triggerEvent` via `revalidatePendingPushBanners`. Successful push scheduling is tracked in `pushValidatedBannerIds` so `createBanners` does not schedule the same banner again from the normal startup path.
> 
> **Event matching** is tightened: a trigger with **no event properties** only matches events with **empty** properties (in both multi-event and current-event checks). Banner fetch now resets **`allNotificationBanners`** vs **`allBanners`** by source instead of clearing both lists, and the old **`isBannerFromNotification`** skip when adding to `filteredBanners` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cbceced89d3ddcc383abe603471e43a2588063f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CP-12056: push-attached app banners with event triggers now show even if the event is tracked after opening the push. We queue these banners, re-validate on `triggerEvent`, and de-duplicate banners already scheduled via push.

- **Bug Fixes**
  - Queue event-triggered push banners and re-validate on `triggerEvent`.
  - Tighten event-property matching: empty condition matches only events with no properties (history and current).
  - Initialize `allNotificationBanners` or `allBanners` based on request type.
  - De-duplicate banners: mark push-validated IDs to skip re-adding in the default flow; removed `isBannerFromNotification`.

<sup>Written for commit 9cbceced89d3ddcc383abe603471e43a2588063f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

