### PR TITLE
hotfix/CP-12084 - fix scrolling in app banners due to wrong display metrics

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -753,23 +753,40 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     return Math.max(Math.min(screenWidth / 400.0f, 10f), 1.0f);
   }
 
-  private void fixFullscreenHtmlBannerUI(LinearLayout body, ConstraintLayout webLayout, WebView webView) {
-    DisplayMetrics displayMetrics = new DisplayMetrics();
-    activity.getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+  private int getBannerHostWidthPx() {
+    if (activity != null) {
+      View decor = activity.getWindow().getDecorView();
+      if (decor.getWidth() > 0) {
+        return decor.getWidth();
+      }
+    }
+    return Resources.getSystem().getDisplayMetrics().widthPixels;
+  }
 
-    int screenWidth = displayMetrics.widthPixels;
-    int screenHeight = displayMetrics.heightPixels;
+  private int getBannerHostHeightPx() {
+    if (activity != null) {
+      View decor = activity.getWindow().getDecorView();
+      if (decor.getHeight() > 0) {
+        return decor.getHeight();
+      }
+    }
+    return Resources.getSystem().getDisplayMetrics().heightPixels;
+  }
+
+  private void fixFullscreenHtmlBannerUI(LinearLayout body, ConstraintLayout webLayout, WebView webView) {
+    int hostWidth = getBannerHostWidthPx();
+    int hostHeight = getBannerHostHeightPx();
 
     ConstraintSet constraintSet = new ConstraintSet();
     constraintSet.clone(webLayout);
-    constraintSet.constrainMinHeight(R.id.webView, screenHeight);
+    constraintSet.constrainMinHeight(R.id.webView, hostHeight);
     constraintSet.applyTo(webLayout);
 
     body.setPadding(0, 0, 0, 0);
 
     ViewGroup.LayoutParams layoutParams = webView.getLayoutParams();
-    layoutParams.width = screenWidth;
-    layoutParams.height = screenHeight;
+    layoutParams.width = hostWidth;
+    layoutParams.height = hostHeight;
     webView.setLayoutParams(layoutParams);
 
     appBannerPopup.getViewPager2().getChildAt(0).setOverScrollMode(View.OVER_SCROLL_NEVER);
@@ -942,6 +959,16 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
             "    } catch (e) {}\n" +
             "  }\n" +
             "  function scheduleMeasure() { setTimeout(measureCleverPushBanner, 50); }\n" +
+            "  var measureTimeout;\n" +
+            "  function debouncedMeasure() {\n" +
+            "    if (measureTimeout) { clearTimeout(measureTimeout); }\n" +
+            "    measureTimeout = setTimeout(measureCleverPushBanner, 50);\n" +
+            "  }\n" +
+            "  if (typeof MutationObserver !== 'undefined' && document.body) {\n" +
+            "    var observer = new MutationObserver(debouncedMeasure);\n" +
+            "    observer.observe(document.body, { childList: true, subtree: true, attributes: true, characterData: true });\n" +
+            "    setTimeout(function() { observer.disconnect(); }, 15000);\n" +
+            "  }\n" +
             "  if (document.readyState === 'complete') {\n" +
             "    scheduleMeasure();\n" +
             "  } else {\n" +
@@ -966,13 +993,13 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
    * viewport for "position: fixed" rendering without forcing the popup to fullscreen.
    */
   private void applyNonBlockingBannerUI(LinearLayout body, ConstraintLayout webLayout, WebView webView) {
-    int screenHeight = Resources.getSystem().getDisplayMetrics().heightPixels;
+    int hostHeight = getBannerHostHeightPx();
     boolean isFullScreenBanner =
         appBannerPopup != null
             && appBannerPopup.getData() != null
             && "full".equalsIgnoreCase(appBannerPopup.getData().getPositionType());
 
-    int webViewHeightPx = isFullScreenBanner ? screenHeight : (int) (screenHeight * 0.6);
+    int webViewHeightPx = isFullScreenBanner ? hostHeight : (int) (hostHeight * 0.6);
 
     ConstraintSet constraintSet = new ConstraintSet();
     constraintSet.clone(webLayout);
@@ -1210,8 +1237,9 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
         activity.runOnUiThread(() -> {
           try {
             if (appBannerPopup != null) {
+              int webViewHeightPx = webView.getHeight();
               appBannerPopup.applyMeasuredHtmlBannerBounds(
-                  leftCss, topCss, widthCss, heightCss, viewportWidthCss, viewportHeightCss);
+                  leftCss, topCss, widthCss, heightCss, viewportWidthCss, viewportHeightCss, webViewHeightPx);
             }
           } catch (Exception ex) {
             Logger.e(TAG, "Error applying measured HTML banner bounds.", ex);

--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerPopup.java
@@ -470,9 +470,12 @@ public class AppBannerPopup {
         // (where HTML using "position: fixed; bottom: ...;" renders) inside the popup
         // window even after applyMeasuredHtmlBannerBounds shrinks the popup to wrap
         // only the banner area.
-        int screenHeightPx = activity.getResources().getDisplayMetrics().heightPixels;
+        int hostHeightPx = activity.getWindow().getDecorView().getHeight();
+        if (hostHeightPx <= 0) {
+          hostHeightPx = activity.getResources().getDisplayMetrics().heightPixels;
+        }
         FrameLayout.LayoutParams nonBlockingBodyParams =
-            new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, screenHeightPx);
+            new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, hostHeightPx);
         nonBlockingBodyParams.gravity = Gravity.BOTTOM;
         body.setLayoutParams(nonBlockingBodyParams);
       } else {
@@ -810,10 +813,17 @@ public class AppBannerPopup {
    */
   public void applyMeasuredHtmlBannerBounds(int leftCss, int topCss, int widthCss, int heightCss,
                                             int viewportWidthCss, int viewportHeightCss) {
+    applyMeasuredHtmlBannerBounds(
+        leftCss, topCss, widthCss, heightCss, viewportWidthCss, viewportHeightCss, 0);
+  }
+
+  public void applyMeasuredHtmlBannerBounds(int leftCss, int topCss, int widthCss, int heightCss,
+                                            int viewportWidthCss, int viewportHeightCss,
+                                            int webViewHeightPx) {
     try {
       if (Looper.myLooper() != Looper.getMainLooper()) {
         mainHandler.post(() -> applyMeasuredHtmlBannerBounds(
-            leftCss, topCss, widthCss, heightCss, viewportWidthCss, viewportHeightCss));
+            leftCss, topCss, widthCss, heightCss, viewportWidthCss, viewportHeightCss, webViewHeightPx));
         return;
       }
       if (!isHTMLBanner()) return;
@@ -823,10 +833,12 @@ public class AppBannerPopup {
       if (heightCss <= 0) return;
 
       DisplayMetrics dm = activity.getResources().getDisplayMetrics();
-      int screenWidth = dm.widthPixels;
-      int screenHeight = dm.heightPixels;
+      View decor = activity.getWindow().getDecorView();
+      int screenWidth = decor.getWidth() > 0 ? decor.getWidth() : dm.widthPixels;
+      int screenHeight = decor.getHeight() > 0 ? decor.getHeight() : dm.heightPixels;
+      int viewportHeightPx = webViewHeightPx > 0 ? webViewHeightPx : viewportHeightCss;
 
-      float scaleY = (float) screenHeight / viewportHeightCss;
+      float scaleY = (float) viewportHeightPx / viewportHeightCss;
       int topPx = Math.max(0, (int) (topCss * scaleY));
       int heightPx = (int) (heightCss * scaleY);
       int marginPx = (int) (10 * dm.density);

--- a/cleverpush/src/main/res/layout/app_banner_html.xml
+++ b/cleverpush/src/main/res/layout/app_banner_html.xml
@@ -8,7 +8,6 @@
         android:id="@+id/webView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginBottom="15dp"
         app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintDimensionRatio="1"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches non-blocking HTML banner layout, popup resizing, and JS measurement bridge; wrong sizing could misplace banners or break pass-through touches, but scope is limited to app banner UI.
> 
> **Overview**
> **Non-blocking HTML app banners** now size the WebView and popup using the **activity decor view** width/height (with display-metrics fallback) instead of raw screen pixels, in fullscreen layout, non-blocking WebView height (full vs 60%), and popup body height for full HTML banners.
> 
> **JS-to-native bounds** mapping uses the **actual WebView height in px** when converting CSS measurements to popup position/size (`scaleY` vs `window.innerHeight`), and re-measures when the DOM changes via a **debounced `MutationObserver`** (auto-disconnect after 15s).
> 
> Removes the **15dp bottom margin** on the HTML banner `WebView` layout so content and touch/scroll align with the measured banner area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6980a73f6d806b82555e597507ac0501887deaf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scrolling and layout for non-blocking HTML app banners by sizing the `WebView` to the host window and dynamically remeasuring content. Addresses CP-12084 where banners were forced fullscreen, breaking scroll and positioning.

- **Bug Fixes**
  - Use host `DecorView` width/height instead of system display metrics to size the banner and popup.
  - Scale and position using the actual `WebView` height in `applyMeasuredHtmlBannerBounds` to align CSS viewport with the popup.
  - Add a debounced DOM `MutationObserver` to remeasure on content changes for up to 15s.
  - Remove bottom margin from `app_banner_html.xml` and disable overscroll to avoid extra spacing and flicks.

<sup>Written for commit 6980a73f6d806b82555e597507ac0501887deaf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

