### PR TITLE
feature/cp-11977-support-platform-specific-font-names-for-in-app-banners

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/AppBannerCarouselAdapter.java
@@ -303,9 +303,13 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     button.setText(text);
     button.setTextSize(TypedValue.COMPLEX_UNIT_SP, block.getSize() * 4 / 3);
 
-    if (block.getFamily() != null) {
+    String fontFamily = block.getFontFamilyAndroid() != null
+            ? block.getFontFamilyAndroid()
+            : block.getFamily();
+
+    if (fontFamily != null) {
       try {
-        Typeface font = FontUtils.findFont(activity, block.getFamily());
+        Typeface font = FontUtils.findFont(activity, fontFamily);
         button.setTypeface(font);
       } catch (Exception ex) {
         Logger.e(TAG, "Error in AppBanner composeButtonBlock setTypeface.", ex);
@@ -473,9 +477,13 @@ public class AppBannerCarouselAdapter extends RecyclerView.Adapter<AppBannerCaro
     }
     textView.setTextColor(ColorUtils.parseColor(textColor));
 
-    if (block.getFamily() != null) {
+    String fontFamily = block.getFontFamilyAndroid() != null
+            ? block.getFontFamilyAndroid()
+            : block.getFamily();
+
+    if (fontFamily != null) {
       try {
-        Typeface font = FontUtils.findFont(activity, block.getFamily());
+        Typeface font = FontUtils.findFont(activity, fontFamily);
         textView.setTypeface(font);
       } catch (Exception ex) {
         Logger.e(TAG, "Error in AppBanner composeTextBlock setTypeface.", ex);

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/blocks/BannerButtonBlock.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/blocks/BannerButtonBlock.java
@@ -24,6 +24,7 @@ public class BannerButtonBlock extends BannerBlock {
   private List<BannerAction> actions;
   private List<BannerBlockScreen> blockScreens;
   private String family = null;
+  private String fontFamilyAndroid = null;
   private String id;
   private int borderWidth;
   private String borderColor;
@@ -78,6 +79,10 @@ public class BannerButtonBlock extends BannerBlock {
 
   public String getFamily() {
     return family;
+  }
+
+  public String getFontFamilyAndroid() {
+    return fontFamilyAndroid;
   }
 
   public String getId() {
@@ -135,6 +140,10 @@ public class BannerButtonBlock extends BannerBlock {
 
     if (json.has("family") && !json.optString("family").isEmpty()) {
       buttonBlock.family = json.optString("family");
+    }
+
+    if (json.has("fontFamilyAndroid") && !json.optString("fontFamilyAndroid").isEmpty()) {
+      buttonBlock.fontFamilyAndroid = json.optString("fontFamilyAndroid");
     }
 
     if (json.has("actions")) {

--- a/cleverpush/src/main/java/com/cleverpush/banner/models/blocks/BannerTextBlock.java
+++ b/cleverpush/src/main/java/com/cleverpush/banner/models/blocks/BannerTextBlock.java
@@ -14,6 +14,7 @@ public final class BannerTextBlock extends BannerBlock {
   private int size;
   private Alignment alignment;
   private String family = null;
+  private String fontFamilyAndroid = null;
   private String id;
   private List<BannerBlockScreen> blockScreens;
   private String html;
@@ -45,6 +46,10 @@ public final class BannerTextBlock extends BannerBlock {
     return family;
   }
 
+  public String getFontFamilyAndroid() {
+    return fontFamilyAndroid;
+  }
+
   public String getId() {
     return id;
   }
@@ -72,6 +77,10 @@ public final class BannerTextBlock extends BannerBlock {
     textBlock.alignment = Alignment.fromString(json.getString("alignment"));
     if (json.has("family") && !json.optString("family").isEmpty()) {
       textBlock.family = json.optString("family");
+    }
+
+    if (json.has("fontFamilyAndroid") && !json.optString("fontFamilyAndroid").isEmpty()) {
+      textBlock.fontFamilyAndroid = json.optString("fontFamilyAndroid");
     }
 
     textBlock.blockScreens = new LinkedList<>();

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
@@ -203,7 +203,7 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
         Typeface font = FontUtils.findFont(activity, fontFamily);
         button.setTypeface(font);
       } catch (Exception ex) {
-        Logger.e(TAG, "Error in AppBanner composeButtonBlock setTypeface.", ex);
+        Logger.e(TAG, "Error in InboxView composeButtonBlock setTypeface.", ex);
       }
     }
 
@@ -344,7 +344,7 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
         Typeface font = FontUtils.findFont(activity, fontFamily);
         textView.setTypeface(font);
       } catch (Exception ex) {
-        Logger.e(TAG, "Error in AppBanner composeTextBlock setTypeface.", ex);
+        Logger.e(TAG, "Error in InboxView composeTextBlock setTypeface.", ex);
       }
     }
 

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailBannerCarouselAdapter.java
@@ -194,12 +194,16 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
     button.setText(block.getText());
     button.setTextSize(TypedValue.COMPLEX_UNIT_SP, block.getSize() * 4 / 3);
 
-    if (block.getFamily() != null) {
+    String fontFamily = block.getFontFamilyAndroid() != null
+            ? block.getFontFamilyAndroid()
+            : block.getFamily();
+
+    if (fontFamily != null) {
       try {
-        Typeface font = FontUtils.findFont(activity, block.getFamily());
+        Typeface font = FontUtils.findFont(activity, fontFamily);
         button.setTypeface(font);
       } catch (Exception ex) {
-        Logger.e(TAG, "Error in InboxView composeButtonBlock setTypeface.", ex);
+        Logger.e(TAG, "Error in AppBanner composeButtonBlock setTypeface.", ex);
       }
     }
 
@@ -331,12 +335,16 @@ public class InboxDetailBannerCarouselAdapter extends RecyclerView.Adapter<Inbox
     }
     textView.setTextColor(ColorUtils.parseColor(textColor));
 
-    if (block.getFamily() != null) {
+    String fontFamily = block.getFontFamilyAndroid() != null
+            ? block.getFontFamilyAndroid()
+            : block.getFamily();
+
+    if (fontFamily != null) {
       try {
-        Typeface font = FontUtils.findFont(activity, block.getFamily());
+        Typeface font = FontUtils.findFont(activity, fontFamily);
         textView.setTypeface(font);
       } catch (Exception ex) {
-        Logger.e(TAG, "Error in InboxView composeTextBlock setTypeface.", ex);
+        Logger.e(TAG, "Error in AppBanner composeTextBlock setTypeface.", ex);
       }
     }
 


### PR DESCRIPTION
Added platform-specific font support for In-App Banners

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized presentation change with backward-compatible fallback to existing `family`; typeface failures remain caught and logged.
> 
> **Overview**
> Adds optional **`fontFamilyAndroid`** on banner text and button blocks so payloads can supply Android font names that differ from the shared **`family`** field (CP-11977).
> 
> **`BannerTextBlock`** and **`BannerButtonBlock`** now read **`fontFamilyAndroid`** from JSON and expose getters. **`AppBannerCarouselAdapter`** and **`InboxDetailBannerCarouselAdapter`** resolve typefaces with **`fontFamilyAndroid`** when set, otherwise **`family`**, for both text and button rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433afda0487747d59f0204be24f5243808503865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Android-specific font support for in-app banners and the Inbox detail view (CP‑11977). Text and buttons can set `fontFamilyAndroid`, falling back to `family`.

- **New Features**
  - Parse and expose `fontFamilyAndroid` in `BannerTextBlock` and `BannerButtonBlock`.
  - Prefer `fontFamilyAndroid` over `family` when resolving typefaces in `AppBannerCarouselAdapter` and `InboxDetailBannerCarouselAdapter`.

<sup>Written for commit 433afda0487747d59f0204be24f5243808503865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

