### PR TITLE
feature/cp-12031-cleverpush-campaigns-showing-0-revenue-despite-recorded

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -3358,7 +3358,7 @@ public class CleverPush {
                 String lastClickedNotificationId = sharedPreferences.getString(CleverPushPreferences.LAST_CLICKED_NOTIFICATION_ID, null);
                 String lastClickedNotificationTime = sharedPreferences.getString(CleverPushPreferences.LAST_CLICKED_NOTIFICATION_TIME, null);
 
-                if (lastClickedNotificationId != null && !lastClickedNotificationId.isEmpty() && isWithin60Minutes(lastClickedNotificationTime)) {
+                if (lastClickedNotificationId != null && !lastClickedNotificationId.isEmpty() && isWithin24Hours(lastClickedNotificationTime)) {
                   jsonBody.put("notificationId", lastClickedNotificationId);
                 }
               } catch (JSONException ex) {
@@ -4866,9 +4866,9 @@ public class CleverPush {
   }
 
   /**
-   * Method to check if the lastClickedNotificationTime is within 60 minutes of current date and time
+   * Method to check if the lastClickedNotificationTime is within 24 hours of current date and time
    * */
-  private boolean isWithin60Minutes(String lastClickedNotificationTime) {
+  private boolean isWithin24Hours(String lastClickedNotificationTime) {
     if (lastClickedNotificationTime == null || lastClickedNotificationTime.isEmpty()) {
       return false;
     }
@@ -4877,8 +4877,8 @@ public class CleverPush {
       Date lastClickedTime = sdf.parse(lastClickedNotificationTime);
       Date currentTime = Calendar.getInstance().getTime();
       long diffInMilliseconds = Math.abs(currentTime.getTime() - lastClickedTime.getTime());
-      long diffInMinutes = diffInMilliseconds / (60 * 1000);
-      return diffInMinutes <= 60;
+      long diffInHours = diffInMilliseconds / (60 * 60 * 1000);
+      return diffInHours < 24;
     } catch (Exception e) {
       Logger.e(LOG_TAG, "Error parsing date", e);
       return false;


### PR DESCRIPTION
Extend the notificationId attribution window for `/subscription/conversion` from 60 minutes to 24 hours.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversion attribution logic for analytics and campaign revenue; wider window increases attributed conversions but may over-attribute purchases unrelated to the notification.
> 
> **Overview**
> Extends how long a **notification click** can be tied to later **conversion events** on Android. When `trackEvent` posts to `/subscription/conversion`, it still adds `notificationId` from the last clicked notification in SharedPreferences, but only if that click is still considered recent.
> 
> The attribution window grows from **60 minutes** to **24 hours**. The helper is renamed from `isWithin60Minutes` to `isWithin24Hours`, and the check now compares elapsed time in hours with **`diffInHours < 24`** instead of minutes **`<= 60`**.
> 
> This should help campaign revenue show up when users convert more than an hour after opening a push but within a day.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc61878977ec8a953e760055f783eba7fe50bc3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the `notificationId` attribution window for `/subscription/conversion` from 60 minutes to 24 hours so conversions from a clicked notification within a day are attributed. Fixes CP-12031 where CleverPush campaigns showed 0 revenue due to the shorter window.

<sup>Written for commit fc61878977ec8a953e760055f783eba7fe50bc3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

