### PR TITLE
feature/cp-11437-app-push-control-notification-sound-for-grouped

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -4647,6 +4647,26 @@ public class CleverPush {
     editor.apply();
   }
 
+  public void setGroupNotificationSoundMode(GroupNotificationSoundMode mode) {
+    if (mode == null) {
+      mode = GroupNotificationSoundMode.ALL_NOTIFICATIONS;
+    }
+    SharedPreferences sharedPreferences = getSharedPreferences(getContext());
+    SharedPreferences.Editor editor = sharedPreferences.edit();
+    editor.putString(CleverPushPreferences.GROUP_NOTIFICATION_SOUND_MODE, mode.getCode());
+    editor.apply();
+  }
+
+  public GroupNotificationSoundMode getGroupNotificationSoundMode() {
+    if (getContext() == null) {
+      return GroupNotificationSoundMode.ALL_NOTIFICATIONS;
+    }
+    SharedPreferences sharedPreferences = getSharedPreferences(getContext());
+    String code = sharedPreferences.getString(CleverPushPreferences.GROUP_NOTIFICATION_SOUND_MODE, null);
+    GroupNotificationSoundMode mode = code != null ? GroupNotificationSoundMode.lookupByCode(code) : null;
+    return mode != null ? mode : GroupNotificationSoundMode.ALL_NOTIFICATIONS;
+  }
+
   public void setUpNotificationCategoryGroups() {
     getChannelConfig(config -> {
       if (config == null) {

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -4648,8 +4648,17 @@ public class CleverPush {
   }
 
   public void setGroupNotificationSoundMode(GroupNotificationSoundMode mode) {
+    if (getContext() == null) {
+      Logger.w(LOG_TAG, "setGroupNotificationSoundMode: context is null");
+      return;
+    }
     if (mode == null) {
       mode = GroupNotificationSoundMode.ALL_NOTIFICATIONS;
+    }
+    if (mode == GroupNotificationSoundMode.FIRST_IN_GROUP_ONLY
+        && Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      Logger.w(LOG_TAG, "setGroupNotificationSoundMode: FIRST_IN_GROUP_ONLY requires Android 6.0 (API 23) "
+          + "or higher. The mode will be ignored on this device and ALL_NOTIFICATIONS will be applied.");
     }
     SharedPreferences sharedPreferences = getSharedPreferences(getContext());
     SharedPreferences.Editor editor = sharedPreferences.edit();

--- a/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPushPreferences.java
@@ -39,6 +39,7 @@ public class CleverPushPreferences {
   public static final String TOPIC_LAST_CHECKED = "CleverPush_TOPIC_LAST_CHECKED";
   public static final String LAST_TIME_AUTO_SHOWED = "CleverPush_LAST_TIME_AUTO_SHOWED";
   public static final String NOTIFICATION_STYLE = "CleverPush_NOTIFICATION_STYLE";
+  public static final String GROUP_NOTIFICATION_SOUND_MODE = "CleverPush_GROUP_NOTIFICATION_SOUND_MODE";
   public static final String DEVICE_ID = "CleverPush_DEVICE_ID";
   public static final String SILENT_PUSH_APP_BANNER = "CleverPush_SILENT_PUSH_APP_BANNER";
   public static final String APP_INSTALLATION_DATE = "CleverPush_APP_INSTALLATION_DATE";

--- a/cleverpush/src/main/java/com/cleverpush/GroupNotificationSoundMode.java
+++ b/cleverpush/src/main/java/com/cleverpush/GroupNotificationSoundMode.java
@@ -1,0 +1,33 @@
+package com.cleverpush;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum GroupNotificationSoundMode {
+
+  ALL_NOTIFICATIONS("ALL_NOTIFICATIONS"),
+  FIRST_IN_GROUP_ONLY("FIRST_IN_GROUP_ONLY");
+
+  private static final Map<String, GroupNotificationSoundMode> valuesByCode;
+
+  static {
+    valuesByCode = new HashMap<>(values().length);
+    for (GroupNotificationSoundMode value : values()) {
+      valuesByCode.put(value.code, value);
+    }
+  }
+
+  private final String code;
+
+  GroupNotificationSoundMode(String code) {
+    this.code = code;
+  }
+
+  public static GroupNotificationSoundMode lookupByCode(String code) {
+    return valuesByCode.get(code);
+  }
+
+  public String getCode() {
+    return code;
+  }
+}

--- a/cleverpush/src/main/java/com/cleverpush/service/NotificationService.java
+++ b/cleverpush/src/main/java/com/cleverpush/service/NotificationService.java
@@ -25,6 +25,7 @@ import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.RemoteViews;
 
+import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
@@ -32,6 +33,7 @@ import androidx.core.content.ContextCompat;
 import com.cleverpush.BadgeHelper;
 import com.cleverpush.CleverPush;
 import com.cleverpush.CleverPushPreferences;
+import com.cleverpush.GroupNotificationSoundMode;
 import com.cleverpush.Notification;
 import com.cleverpush.NotificationAction;
 import com.cleverpush.NotificationCarouselItem;
@@ -292,6 +294,11 @@ public class NotificationService {
       notificationBuilder = new NotificationCompat.Builder(context);
     }
 
+    String groupKey = getGroupKeyForCurrentChannel(notification);
+    GroupNotificationSoundMode groupSoundMode = getGroupNotificationSoundMode(context);
+    boolean suppressSound =
+        shouldSuppressGroupSound(groupSoundMode, hasActiveNotificationsInGroup(context, groupKey));
+
     notificationBuilder = notificationBuilder
         .setContentIntent(contentIntent)
         .setDeleteIntent(this.getNotificationDeleteIntent(context, notification))
@@ -299,8 +306,15 @@ public class NotificationService {
         .setContentText(text)
         .setSmallIcon(getSmallIcon(context))
         .setAutoCancel(true)
-        .setGroup(getGroupKeyForCurrentChannel(notification))
-        .setSound(soundUri);
+        .setGroup(groupKey)
+        .setSound(suppressSound ? null : soundUri);
+
+    if (suppressSound) {
+      // On Android O+ the sound comes from the notification channel and cannot be disabled per
+      // notification via setSound. Deferring the alert to the group summary (which never alerts in
+      // FIRST_IN_GROUP_ONLY mode) keeps this notification silent without modifying the channel.
+      notificationBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
+    }
 
     if (notification.getActions() != null && notification.getActions().length > 0) {
       List<NotificationCompat.Action> actions = new ArrayList<>();
@@ -439,6 +453,63 @@ public class NotificationService {
     return NotificationStyle.AUTO;
   }
 
+  GroupNotificationSoundMode getGroupNotificationSoundMode(Context context) {
+    try {
+      SharedPreferences sharedPreferences = SharedPreferencesManager.getSharedPreferences(context);
+      String code = sharedPreferences.getString(CleverPushPreferences.GROUP_NOTIFICATION_SOUND_MODE, null);
+      if (code != null) {
+        GroupNotificationSoundMode mode = GroupNotificationSoundMode.lookupByCode(code);
+        if (mode != null) {
+          return mode;
+        }
+      }
+    } catch (Exception exception) {
+      Logger.e(LOG_TAG, "NotificationService getGroupNotificationSoundMode: Error getting groupNotificationSoundMode",
+          exception);
+    }
+
+    return GroupNotificationSoundMode.ALL_NOTIFICATIONS;
+  }
+
+  boolean shouldSuppressGroupSound(GroupNotificationSoundMode mode, boolean groupHasActiveNotifications) {
+    return mode == GroupNotificationSoundMode.FIRST_IN_GROUP_ONLY && groupHasActiveNotifications;
+  }
+
+  boolean hasActiveNotificationsInGroup(Context context, String groupKey) {
+    if (groupKey == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return false;
+    }
+
+    try {
+      StatusBarNotification[] activeNotifications = BadgeHelper.getActiveNotifications(context);
+      return containsActiveGroupChild(activeNotifications, groupKey);
+    } catch (Exception exception) {
+      Logger.e(LOG_TAG, "NotificationService: Error while checking active notifications in group", exception);
+      return false;
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.M)
+  boolean containsActiveGroupChild(StatusBarNotification[] activeNotifications, String groupKey) {
+    if (activeNotifications == null || groupKey == null) {
+      return false;
+    }
+    for (StatusBarNotification activeNotification : activeNotifications) {
+      android.app.Notification active = activeNotification.getNotification();
+      if (active == null) {
+        continue;
+      }
+      boolean isGroupSummary = (active.flags & NotificationCompat.FLAG_GROUP_SUMMARY) != 0;
+      if (isGroupSummary) {
+        continue;
+      }
+      if (groupKey.equals(active.getGroup())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   int showNotification(Context context, Notification notification, Subscription subscription) {
     String notificationStr = notification.getRawPayload();
     String subscriptionStr = subscription.getRawPayload();
@@ -494,6 +565,8 @@ public class NotificationService {
     String title = VoucherCodeUtils.replaceVoucherCodeString(notification.getTitle(), voucherCode);
     String text = VoucherCodeUtils.replaceVoucherCodeString(notification.getText(), voucherCode);
     String groupKey = getGroupKeyForCurrentChannel(notification);
+    boolean firstInGroupOnly =
+        getGroupNotificationSoundMode(context) == GroupNotificationSoundMode.FIRST_IN_GROUP_ONLY;
 
     NotificationCompat.Builder builder =
             new NotificationCompat.Builder(context, summaryNotificationId)
@@ -508,7 +581,11 @@ public class NotificationService {
                             .addLine(text))
                     .setGroup(groupKey)
                     .setGroupSummary(true)
-                    .setSound(getSoundUri(context, notification));
+                    .setSound(firstInGroupOnly ? null : getSoundUri(context, notification));
+
+    if (firstInGroupOnly) {
+      builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN);
+    }
 
     int effectiveColor = 0;
     NotificationCategory notificationCategory = notification.getCategory();


### PR DESCRIPTION
Added `setGroupNotificationSoundMode(GroupNotificationSoundMode)` to play a sound only for the first notification in a group (FIRST_IN_GROUP_ONLY), keeping ALL_NOTIFICATIONS as default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core notification display and sound/alert behavior across API levels; mis-detection of active group children could mute or double-alert, though defaults preserve existing behavior.
> 
> **Overview**
> Adds **`GroupNotificationSoundMode`** and app APIs **`setGroupNotificationSoundMode`** / **`getGroupNotificationSoundMode`**, persisted via **`CleverPushPreferences.GROUP_NOTIFICATION_SOUND_MODE`**. Default remains **`ALL_NOTIFICATIONS`**; **`FIRST_IN_GROUP_ONLY`** is opt-in (with a warning on API &lt; 23).
> 
> **`NotificationService`** reads the mode when posting grouped notifications: if **`FIRST_IN_GROUP_ONLY`** and the group already has active child notifications, later posts use **`setSound(null)`** and **`GROUP_ALERT_SUMMARY`** so children stay silent on Android O+ without changing channels. Group summary notifications skip sound in that mode and use **`GROUP_ALERT_CHILDREN`** so only the first alert in a group is audible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59e4c9492635f80db4dd1dedb47c2d6c67ef9d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds app-level control to play sound only on the first notification in a group while keeping the default unchanged. Effective on Android 6.0+; older versions ignore the setting.

- **New Features**
  - Added `GroupNotificationSoundMode` with `ALL_NOTIFICATIONS` (default) and `FIRST_IN_GROUP_ONLY`.
  - Added `CleverPush.setGroupNotificationSoundMode(mode)` and `CleverPush.getGroupNotificationSoundMode()` with preference storage.
  - `NotificationService` suppresses sound for later notifications in a group (API 23+): clears per-notification sound, uses `GROUP_ALERT_SUMMARY` for children; the group summary has no sound and uses `GROUP_ALERT_CHILDREN`.

- **Migration**
  - To enable first-only sounds, call `setGroupNotificationSoundMode(FIRST_IN_GROUP_ONLY)` during SDK setup. On API < 23, the mode is ignored and a warning is logged.

<sup>Written for commit b59e4c9492635f80db4dd1dedb47c2d6c67ef9d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

