### PR TITLE
hotfix/cp-12240-getsubscriptionid-hangs-without-subscription

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/AddSubscriptionTags.java
+++ b/cleverpush/src/main/java/com/cleverpush/AddSubscriptionTags.java
@@ -121,6 +121,14 @@ public class AddSubscriptionTags implements AddTagCompletedListener {
               addTagCompletedListener, currentPositionOfTagToAdd, tags));
     } else {
       Logger.d(LOG_TAG, "addSubscriptionTag: There is no subscription for CleverPush SDK.");
+      Exception exception = new Exception("There is no subscription for CleverPush SDK.");
+      if (addTagCompletedListener != null) {
+        addTagCompletedListener.onFailure(exception);
+      }
+      if (completionListener != null) {
+        completionListener.onFailure(exception);
+      }
+      this.finished = true;
     }
   }
 

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -2870,8 +2870,13 @@ public class CleverPush {
 
   private void setSubscriptionAttributeObjectImplementation(String attributeId, Object value, SetSubscriptionAttributeResponseHandler responseHandler) {
     String channelId = getChannelId(getContext());
-    if (isChannelIdInvalid(channelId, "setSubscriptionAttribute"))
+    if (isChannelIdInvalid(channelId, "setSubscriptionAttribute")) {
+      if (responseHandler != null) {
+        responseHandler.getResponseHandler(getSubscriptionAttributes())
+            .onFailure(0, "Channel ID is null or empty.", null);
+      }
       return;
+    }
 
     this.getSubscriptionId(subscriptionId -> {
       if (subscriptionId != null && !subscriptionId.isEmpty()) {
@@ -2898,6 +2903,10 @@ public class CleverPush {
         CleverPushHttpClient.postWithRetry("/subscription/attribute", jsonBody, responseHandler.getResponseHandler(subscriptionAttributes));
       } else {
         Logger.d(LOG_TAG, "setSubscriptionAttribute: There is no subscription for CleverPush SDK.");
+        if (responseHandler != null) {
+          responseHandler.getResponseHandler(getSubscriptionAttributes())
+              .onFailure(0, "There is no subscription for CleverPush SDK.", null);
+        }
       }
     });
   }

--- a/cleverpush/src/main/java/com/cleverpush/CleverPush.java
+++ b/cleverpush/src/main/java/com/cleverpush/CleverPush.java
@@ -1836,6 +1836,9 @@ public class CleverPush {
               new UnsubscribeResponseHandler(this, listener).getResponseHandler());
     } else {
       Logger.d(LOG_TAG, "unsubscribe: There is no subscription for CleverPush SDK.");
+      if (listener != null) {
+        listener.onFailure( new Exception("There is no subscription for CleverPush SDK."));
+      }
       clearSubscriptionData();
     }
   }
@@ -1918,6 +1921,9 @@ public class CleverPush {
               new StopCampaignResponseHandler(this, listener).getResponseHandler());
     } else {
       Logger.d(LOG_TAG, "stopCampaigns: There is no subscription for CleverPush SDK.");
+      if (listener != null) {
+        listener.onFailure( new Exception("There is no subscription for CleverPush SDK."));
+      }
     }
   }
 
@@ -2044,13 +2050,22 @@ public class CleverPush {
   }
 
   public synchronized void getSubscriptionId(SubscribedListener listener) {
-    if (listener != null) {
-      if (subscriptionId == null || subscriptionId.isEmpty()) {
-        Logger.d(LOG_TAG, "getSubscriptionId: There is no subscription for CleverPush SDK.");
-        getSubscriptionIdListeners.add(listener);
-      } else {
-        listener.subscribed(subscriptionId);
-      }
+    if (listener == null) {
+      return;
+    }
+
+    boolean hasSubscription = subscriptionId != null && !subscriptionId.isEmpty();
+    if (hasSubscription) {
+      listener.subscribed(subscriptionId);
+      return;
+    }
+
+    boolean shouldWaitForSubscription = !initialized || isSubscriptionInProgress() || isSubscribed();
+    Logger.d(LOG_TAG, "getSubscriptionId: There is no subscription for CleverPush SDK.");
+    if (shouldWaitForSubscription) {
+      getSubscriptionIdListeners.add(listener);
+    } else {
+      listener.subscribed(null);
     }
   }
 
@@ -2066,17 +2081,17 @@ public class CleverPush {
     subscriptionId = value;
     notifyAll();
 
-    if (subscriptionId != null) {
-      for (SubscribedListener listener : getSubscriptionIdListeners) {
-        if (listener == null) {
-          continue;
-        }
-        listener.subscribed(subscriptionId);
-      }
-      getSubscriptionIdListeners = new ArrayList<>();
-    } else {
+    if (subscriptionId == null || subscriptionId.isEmpty()) {
       Logger.d(LOG_TAG, "setSubscriptionId: There is no subscription for CleverPush SDK.");
     }
+
+    for (SubscribedListener listener : getSubscriptionIdListeners) {
+      if (listener == null) {
+        continue;
+      }
+      listener.subscribed(subscriptionId);
+    }
+    getSubscriptionIdListeners = new ArrayList<>();
   }
 
   public boolean isNotificationReceivedListenerCallback() {
@@ -2460,12 +2475,15 @@ public class CleverPush {
 
   public void addSubscriptionTopic(String topicId, CompletionFailureListener completionListener) {
     String channelId = getChannelId(getContext());
-    if (isChannelIdInvalid(channelId, "addSubscriptionTopic"))
+    if (isChannelIdInvalid(channelId, "addSubscriptionTopic")) {
+      notifyCompletionFailure(completionListener, "Channel ID is null or empty.");
       return;
+    }
 
     this.getSubscriptionId(subscriptionId -> {
       if (subscriptionId == null || subscriptionId.isEmpty()) {
         Logger.d(LOG_TAG, "addSubscriptionTopic: There is no subscription for CleverPush SDK.");
+        notifyNoSubscriptionFailure(completionListener);
         return;
       }
       Set<String> topics = new HashSet<>(this.getSubscriptionTopics());
@@ -2519,12 +2537,15 @@ public class CleverPush {
 
   public void removeSubscriptionTopic(String topicId, CompletionFailureListener completionListener) {
     String channelId = getChannelId(getContext());
-    if (isChannelIdInvalid(channelId, "removeSubscriptionTopic"))
+    if (isChannelIdInvalid(channelId, "removeSubscriptionTopic")) {
+      notifyCompletionFailure(completionListener, "Channel ID is null or empty.");
       return;
+    }
 
     this.getSubscriptionId(subscriptionId -> {
       if (subscriptionId == null || subscriptionId.isEmpty()) {
         Logger.d(LOG_TAG, "removeSubscriptionTopic: There is no subscription for CleverPush SDK.");
+        notifyNoSubscriptionFailure(completionListener);
         return;
       }
       Set<String> topics = new HashSet<>(this.getSubscriptionTopics());
@@ -2727,6 +2748,7 @@ public class CleverPush {
         removeSubscriptionTagsHelper.removeSubscriptionTags();
       } else {
         Logger.d(LOG_TAG, "removeSubscriptionTagTrackingImplementation: There is no subscription for CleverPush SDK.");
+        notifyNoSubscriptionFailure(listener);
       }
     });
   }
@@ -2754,8 +2776,10 @@ public class CleverPush {
   public void setSubscriptionTopics(String[] topicIds, CompletionFailureListener completionListener) {
     new Thread(() -> {
       String channelId = getChannelId(getContext());
-      if (isChannelIdInvalid(channelId, "setSubscriptionTopics"))
+      if (isChannelIdInvalid(channelId, "setSubscriptionTopics")) {
+        notifyCompletionFailure(completionListener, "Channel ID is null or empty.");
         return;
+      }
 
       SharedPreferences sharedPreferences = getSharedPreferences(getContext());
       final int topicsVersion = sharedPreferences.getInt(CleverPushPreferences.SUBSCRIPTION_TOPICS_VERSION, 0) + 1;
@@ -2783,6 +2807,7 @@ public class CleverPush {
               new SetSubscriptionTopicsResponseHandler(this).getResponseHandler(topicIds, completionListener, true));
         } else {
           Logger.d(LOG_TAG, "setSubscriptionTopics: There is no subscription for CleverPush SDK.");
+          notifyNoSubscriptionFailure(completionListener);
         }
       });
     }).start();
@@ -5029,12 +5054,15 @@ public class CleverPush {
   private void setSubscriptionTestStatus(CompletionFailureListener listener, boolean isTest) {
     try {
       String channelId = getChannelId(context);
-      if (isChannelIdInvalid(channelId, "markSubscriptionAsTest"))
+      if (isChannelIdInvalid(channelId, "markSubscriptionAsTest")) {
+        notifyCompletionFailure(listener, "Channel ID is null or empty.");
         return;
+      }
 
       String subscriptionId = getSubscriptionId(getContext());
       if (subscriptionId == null || subscriptionId.isEmpty()) {
         Logger.w(LOG_TAG, "markSubscriptionAsTest: There is no subscriptionId");
+        notifyNoSubscriptionFailure(listener);
         return;
       }
 
@@ -5052,6 +5080,7 @@ public class CleverPush {
               responseHandler);
     } catch (Exception e) {
       Logger.e(LOG_TAG, "markSubscriptionAsTest: Error while marking subscription as test", e);
+      notifyCompletionFailure(listener, e);
     }
   }
 
@@ -5061,6 +5090,20 @@ public class CleverPush {
       return true;
     }
     return false;
+  }
+
+  private void notifyNoSubscriptionFailure(CompletionFailureListener listener) {
+    notifyCompletionFailure(listener, "There is no subscription for CleverPush SDK.");
+  }
+
+  private void notifyCompletionFailure(CompletionFailureListener listener, String message) {
+    notifyCompletionFailure(listener, new Exception(message));
+  }
+
+  private void notifyCompletionFailure(CompletionFailureListener listener, Exception exception) {
+    if (listener != null) {
+      listener.onFailure(exception);
+    }
   }
 
   public boolean isAppBannersNonBlocking() {

--- a/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionAttributes.java
+++ b/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionAttributes.java
@@ -107,6 +107,13 @@ public class RemoveSubscriptionAttributes implements RemoveAttributeCompletedLis
               onRemoveAttributeCompleted, currentPositionOfAttributeToRemove));
     } else {
       Logger.d(LOG_TAG, "removeSubscriptionAttribute: There is no subscription for CleverPush SDK.");
+      Exception exception = new Exception("There is no subscription for CleverPush SDK.");
+      if (onRemoveAttributeCompleted != null) {
+        onRemoveAttributeCompleted.onFailure(exception);
+      } else if (completionListener != null) {
+        completionListener.onFailure(exception);
+      }
+      this.finished = true;
     }
   }
 

--- a/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionTags.java
+++ b/cleverpush/src/main/java/com/cleverpush/RemoveSubscriptionTags.java
@@ -111,6 +111,13 @@ public class RemoveSubscriptionTags implements RemoveTagCompletedListener {
               onRemoveTagCompleted, currentPositionOfTagToRemove, tags));
     } else {
       Logger.d(LOG_TAG, "removeSubscriptionTag: There is no subscription for CleverPush SDK.");
+      Exception exception = new Exception("There is no subscription for CleverPush SDK.");
+      if (onRemoveTagCompleted != null) {
+        onRemoveTagCompleted.onFailure(exception);
+      } else if (completionListener != null) {
+        completionListener.onFailure(exception);
+      }
+      this.finished = true;
     }
   }
 


### PR DESCRIPTION
Prevent getSubscriptionId and CompletionFailureListener APIs from hanging indefinitely when autoRegister is false and the user never subscribes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hangs when there’s no subscription by returning null or invoking failure callbacks instead of waiting forever. Addresses Linear CP-12240 when `autoRegister` is false and the user never subscribes.

- **Bug Fixes**
  - `CleverPush.getSubscriptionId(SubscribedListener)` now calls the listener immediately with the current ID, queues only while initializing or subscribing, and returns `null` otherwise; `setSubscriptionId` notifies all queued listeners even when the value is `null` or empty.
  - All subscription-required APIs now fail fast with a clear error when there’s no subscription or the channel ID is missing: `unsubscribe`, `stopCampaigns`, add/remove/set topics, add/remove tags, remove attributes, tag tracking removal, set attributes, and `mark/unmarkSubscriptionAsTest`. Tag/attribute helpers also finish the operation after reporting failure.

<sup>Written for commit 43337576e9bac3509b29b8b1c00ae26e108d7aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

