### PR TITLE
hotfix/cp-12251-inboxdetailactivity-crashes-with-noactionbar-host-themes

### DIFF
--- a/cleverpush/src/main/AndroidManifest.xml
+++ b/cleverpush/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application>
-        <activity android:name=".inbox.InboxDetailActivity" />
+        <activity
+            android:name=".inbox.InboxDetailActivity"
+            android:theme="@style/cleverpush_inbox_detail_theme" />
         <activity
             android:name="com.cleverpush.NotificationOpenedActivity"
             android:exported="true"

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailActivity.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxDetailActivity.java
@@ -134,8 +134,10 @@ public class InboxDetailActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_inbox_detail);
 
-    getSupportActionBar().setTitle("Message Detail");
-    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    if (getSupportActionBar() != null) {
+      getSupportActionBar().setTitle("Message Detail");
+      getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    }
 
     this.context = this;
     this.activity = this;
@@ -150,10 +152,10 @@ public class InboxDetailActivity extends AppCompatActivity {
   private void init() {
     int layoutId = R.layout.activity_inbox_detail;
     popupRoot = createLayout(layoutId);
-    handleBundleData(getIntent().getExtras());
     handlerThread.start();
     handler = new Handler(handlerThread.getLooper());
     mainHandler = new CustomExceptionHandler(activity.getMainLooper());
+    handleBundleData(getIntent().getExtras());
   }
 
   private View createLayout(int layoutId) {

--- a/cleverpush/src/main/java/com/cleverpush/inbox/InboxViewListAdapter.java
+++ b/cleverpush/src/main/java/com/cleverpush/inbox/InboxViewListAdapter.java
@@ -7,6 +7,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Typeface;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import com.cleverpush.util.FontUtils;
 import com.cleverpush.util.Logger;
@@ -21,7 +23,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.cleverpush.ActivityLifecycleListener;
 import com.cleverpush.CleverPush;
 import com.cleverpush.Notification;
 import com.cleverpush.R;
@@ -208,7 +209,7 @@ public class InboxViewListAdapter extends RecyclerView.Adapter<InboxViewHolder> 
 
         Bitmap bitmap = BitmapFactory.decodeStream(inputStream[0]);
         if (bitmap != null) {
-          ActivityLifecycleListener.currentActivity.runOnUiThread(new Runnable() {
+          new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
               image.setImageBitmap(Bitmap.createScaledBitmap(bitmap, 50, 50, false));

--- a/cleverpush/src/main/res/values/styles.xml
+++ b/cleverpush/src/main/res/values/styles.xml
@@ -31,6 +31,9 @@
     <style name="cleverpush_app_banner_theme" parent="Theme.AppCompat.DayNight.NoActionBar">
     </style>
 
+    <style name="cleverpush_inbox_detail_theme" parent="Theme.AppCompat.DayNight.DarkActionBar">
+    </style>
+
     <style name="Theme.Transparent" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowIsTranslucent">true</item>


### PR DESCRIPTION
Fixed a crash in `InboxDetailActivity` when the host app uses a `NoActionBar` theme, a handler initialization crash when opening inbox messages, and an image loading error in `InboxView` when no current activity is available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes when opening inbox messages by making `InboxDetailActivity` work with `NoActionBar` host themes and by stabilizing handler and image loading initialization. Addresses CP-12251.

- **Bug Fixes**
  - Apply `@style/cleverpush_inbox_detail_theme` in manifest and null-check `getSupportActionBar()` to prevent ActionBar NPEs under `NoActionBar` hosts.
  - Initialize `HandlerThread`, `Handler`, and `mainHandler` before `handleBundleData(...)` to avoid handler-related crashes on launch.
  - Load images on the main thread via `new Handler(Looper.getMainLooper()).post(...)` instead of `ActivityLifecycleListener.currentActivity.runOnUiThread`, so it works when no current activity is available.

<sup>Written for commit 25e66ddff550c8c4a2a8a2b59a22790ff6eee1a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized defensive fixes in inbox UI (theme, null checks, init order, main-thread posting) with no auth, data, or API contract changes.
> 
> **Overview**
> Fixes three inbox-related crashes when host apps use **NoActionBar** themes or when lifecycle/activity state is unavailable.
> 
> **Inbox detail screen:** `InboxDetailActivity` is assigned **`cleverpush_inbox_detail_theme`** (`DarkActionBar`) in the manifest so the SDK does not inherit a host **NoActionBar** theme. Action bar setup is guarded with a **null** check on `getSupportActionBar()`. **`handleBundleData`** runs only after the background **`Handler`** is created so banner loading does not touch an uninitialized handler.
> 
> **Inbox list:** Channel/icon bitmaps are applied on the main thread via **`Handler(Looper.getMainLooper())`** instead of **`ActivityLifecycleListener.currentActivity`**, avoiding NPE when there is no tracked current activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e66ddff550c8c4a2a8a2b59a22790ff6eee1a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->