### PR TITLE
hotfix/cp-12250-permissionactivity-crashes-when-intent-extras-are-missing

### DIFF
--- a/cleverpush/src/main/java/com/cleverpush/PermissionActivity.java
+++ b/cleverpush/src/main/java/com/cleverpush/PermissionActivity.java
@@ -46,13 +46,14 @@ public class PermissionActivity extends Activity implements ActivityCompat.OnReq
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    requestPermission(getIntent().getExtras());
+    Intent intent = getIntent();
+    requestPermission(intent == null ? null : intent.getExtras());
   }
 
   @Override
   protected void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
-    requestPermission(intent.getExtras());
+    requestPermission(intent == null ? null : intent.getExtras());
   }
 
   private void requestPermission(Bundle extras) {


### PR DESCRIPTION
Fix crash in PermissionActivity when it is opened without permission extras.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive null checks on a permission trampoline activity; no change to the happy path when extras are present.
> 
> **Overview**
> **Fixes a crash** when `PermissionActivity` is started or delivered an intent without permission extras (or with a null intent).
> 
> `onCreate` and `onNewIntent` now pass `null` into `requestPermission` when `getIntent()` / the incoming intent is null, instead of calling `getExtras()` unconditionally. The existing `requestPermission` path already treats null extras by calling `finish()`, so behavior stays safe without showing a permission dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d0b6010f1bda2891bf06c41f9e85b57092b82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CP-12250. Prevents `PermissionActivity` from crashing when opened without permission extras by safely handling a null `Intent` and extras in `onCreate` and `onNewIntent`.

<sup>Written for commit 82d0b6010f1bda2891bf06c41f9e85b57092b82f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-android-sdk/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

